### PR TITLE
jump_list の改善

### DIFF
--- a/autoload/unite.vim
+++ b/autoload/unite.vim
@@ -135,6 +135,7 @@ let s:LNUM_STATUS = 1
 " buffer number of the unite buffer
 let s:last_unite_bufnr = -1
 let s:unite = {}
+let s:unite_session = 0
 
 let s:default_sources = {}
 let s:default_kinds = {}
@@ -161,6 +162,15 @@ let s:unite_options = [
 " Helper functions."{{{
 function! unite#is_win()"{{{
   return unite#util#is_win()
+endfunction"}}}
+function! unite#context_winnr()"{{{
+  let l:nr = 1
+  while l:nr <= winnr('$')
+    if getwinvar(l:nr, 'unite_session') == s:unite_session
+      return l:nr
+    endif
+    let l:nr += 1
+  endwhile
 endfunction"}}}
 function! unite#get_unite_candidates()"{{{
   return s:get_unite().candidates
@@ -453,6 +463,9 @@ endfunction"}}}
 
 " Command functions.
 function! unite#start(sources, ...)"{{{
+  let s:unite_session += 1
+  let w:unite_session = s:unite_session
+
   if empty(s:default_sources)
     " Initialize load.
     call s:load_default_sources_and_kinds()


### PR DESCRIPTION
unite-outline の自前アクションからのフィードバックです。
主な変更点は、

１、search() によるジャンプ

action__pattern がある場合は search() で位置決めし、同一pattern を検出したら同じく search() で巡回して同一signature の行を探す。g:unite_kind_jump_list_search_range は必要ないので削除。

２、スクロールが先頭に戻る問題への対処

既存のバッファを edit, pedit で再度開くと元のバッファのスクロールがなぜか先頭に戻ってしまうのでそれへの対処。（preview のそれはかなり泥臭いです）

これをやらないと、同一バッファの複数箇所に対して split しても、最後に開いたウィンドウ以外はカーソルが先頭に移動してしまうため使い物になりません。また、preview時にも同じことが起こるので、カーソル位置を保存して、先頭へのスクロールを検出したら元に戻すようにしてます。（そのために、:Unite実行時にフォーカスのあったウィンドウの番号を取得できる関数を追加）

３、ジャンプ後のスクロール調整を制御する変数の追加
g:unite_kind_jump_list_after_jump_scroll

このスクロール調整を preview時にも適用します。

４、signature に何を用いるかは source に任せる

もしかすると source は signature として message digest のようなものを設定するかも知れないので、lines に限定しない。行番号から signature を返す関数は source が実装することとする。

以上です。
コミットを分けるべきなんでしょうが、unite-outline からコピペなので一枚岩になってしまいました。
