### PR TITLE
jump_list の open アクションの改善

### DIFF
--- a/autoload/unite/kinds/jump_list.vim
+++ b/autoload/unite/kinds/jump_list.vim
@@ -42,7 +42,10 @@ let s:kind.action_table.open = {
       \ }
 function! s:kind.action_table.open.func(candidates)"{{{
   for l:candidate in a:candidates
-    execute 'edit' '+call\ s:jump(l:candidate)' '`=l:candidate.action__path`'
+    if bufnr(unite#util#escape_file_searching(l:candidate.action__path)) != bufnr('%')
+      edit `=l:candidate.action__path`
+    endif
+    call s:jump(l:candidate)
 
     " Open folds.
     normal! zv
@@ -54,7 +57,7 @@ let s:kind.action_table.preview = {
       \ 'is_quit' : 0,
       \ }
 function! s:kind.action_table.preview.func(candidate)"{{{
-  execute 'pedit' '+call\ s:jump(a:candidate)' '`=a:candidate.action__path`'
+  pedit +call\ s:jump(a:candidate) `=a:candidate.action__path`
 endfunction"}}}
 "}}}
 


### PR DESCRIPTION
jump_list改善のためのパッチその２

現在、同一バッファ上の複数候補に対して split, below などを実行すると、:edit で再度ファイルを開く副作用（？）により、split元ウィンドウのカーソルがバッファの先頭へ移動してしまうという問題があります。

そのため、最後に開いたウィンドウを除く、すべてのウィンドウにおいてカーソルが先頭に移動してしまい、jump_list としての体をなしません。

参考画像
この候補選択の状態から
http://img.f.hatena.ne.jp/images/fotolife/h/h1mesuke/20101122/20101122153948.png
　↓
split後
http://img.f.hatena.ne.jp/images/fotolife/h/h1mesuke/20101122/20101122153947.png

そこで

この問題への対処として、`action__path` に設定されたパスのバッファが現在の（split元の）バッファと同一であった場合は :edit を実行せず、そのままジャンプだけを行うようにしました。

この変更後に上の画像と同じ操作を行った結果がこちら↓

split後その２
http://img.f.hatena.ne.jp/images/fotolife/h/h1mesuke/20101122/20101122153946.png

きちんとジャンプした位置にカーソルが残ります。（少し見にくいですが、日付の部分を見てもらえば、それぞれジャンプ後の位置をキープしていることがわかります）
