### PR TITLE
unite#util#wcswidth() の改善

### DIFF
--- a/autoload/unite/util.vim
+++ b/autoload/unite/util.vim
@@ -113,6 +113,9 @@ else
   endfunction"}}}
 
   function! unite#util#wcswidth(str)"{{{
+    if s:is_ascii(a:str)
+      return strlen(a:str)
+    end
     let mx_first = '^\(.\)'
     let str = a:str
     let width = 0
@@ -125,6 +128,10 @@ else
       let str = substitute(str, mx_first, '', '')
     endwhile
     return width
+  endfunction"}}}
+
+  function! s:is_ascii(str)"{{{
+    return (a:str =~# '^[\x00-\x7f]*$')
   endfunction"}}}
 
   " UTF-8 only.


### PR DESCRIPTION
Vim 7.2以下のバージョン用の unite#util#wcswidth() の改善パッチです。
与えられた文字列が ASCII の範囲に収まる場合は単に strlen() を呼ぶ、というだけです。

以下は ASCII only な 229 の候補を表示させた際のプロファイル結果。
大幅に改善しました。
### patch適用前

<pre>
FUNCTIONS SORTED ON TOTAL TIME
count  total (s)   self (s)  function
    1   2.900192   0.000534  unite#start()
    1   2.849449   0.000020  unite#force_redraw()
    1   2.537825   0.000247  unite#redraw_candidates()
  687   2.476843   1.779735  unite#util#wcswidth()
  229   2.351930   0.016853  unite#util#truncate_smart()
  458   1.349236   0.035250  unite#util#truncate()
    1   0.009369   0.000034  unite#force_quit_session()
    1   0.005404             unite#mappings#define_default_mappings()
    4   0.005398   0.001245  unite#sources#file_mru#_append()
    1   0.001432   0.001145  unite#sources#outline#get_outline_info()
    5   0.001203   0.000968  unite#sources#directory_mru#_append()
    2   0.000804             unite#sources#tags#_save_last_tagfiles()
   13   0.000756   0.000283  unite#util#substitute_path_separator()
    4   0.000616             unite#sources#buffer#_append()
   14   0.000506             unite#util#is_win()
    4   0.000443             unite#sources#outline#alias()
    2   0.000392             unite#set_substitute_pattern()
    6   0.000306             unite#util#set_default()
    3   0.000287             unite#custom_action()
    4   0.000258   0.000106  unite#loaded_sources_list()

FUNCTIONS SORTED ON SELF TIME
count  total (s)   self (s)  function
  687   2.476843   1.779735  unite#util#wcswidth()
  458   1.349236   0.035250  unite#util#truncate()
  229   2.351930   0.016853  unite#util#truncate_smart()
    1              0.005404  unite#mappings#define_default_mappings()
    4   0.005398   0.001245  unite#sources#file_mru#_append()
    1   0.001432   0.001145  unite#sources#outline#get_outline_info()
    5   0.001203   0.000968  unite#sources#directory_mru#_append()
    2              0.000804  unite#sources#tags#_save_last_tagfiles()
    4              0.000616  unite#sources#buffer#_append()
    1   2.900192   0.000534  unite#start()
   14              0.000506  unite#util#is_win()
    4              0.000443  unite#sources#outline#alias()
    2              0.000392  unite#set_substitute_pattern()
    6              0.000306  unite#util#set_default()
    3              0.000287  unite#custom_action()
   13   0.000756   0.000283  unite#util#substitute_path_separator()
    1   2.537825   0.000247  unite#redraw_candidates()
    1   0.000173   0.000111  unite#gather_candidates()
    4   0.000258   0.000106  unite#loaded_sources_list()
    1   0.000156   0.000092  unite#redraw_status()
</pre>

### patch適用後

<pre>
FUNCTIONS SORTED ON TOTAL TIME
count  total (s)   self (s)  function
    1   0.409791   0.000506  unite#start()
    1   0.361340   0.000020  unite#force_redraw()
    1   0.100477   0.000237  unite#redraw_candidates()
  229   0.066492   0.014633  unite#util#truncate_smart()
  458   0.059396   0.031909  unite#util#truncate()
  687   0.046003   0.014722  unite#util#wcswidth()
    1   0.009235   0.000032  unite#force_quit_session()
    1   0.005714             unite#mappings#define_default_mappings()
    4   0.005092   0.001241  unite#sources#file_mru#_append()
    1   0.001308   0.001053  unite#sources#outline#get_outline_info()
    5   0.001204   0.000979  unite#sources#directory_mru#_append()
    2   0.000743             unite#sources#tags#_save_last_tagfiles()
    4   0.000611             unite#sources#buffer#_append()
   13   0.000568   0.000269  unite#util#substitute_path_separator()
    2   0.000387             unite#set_substitute_pattern()
   14   0.000327             unite#util#is_win()
    6   0.000305             unite#util#set_default()
    3   0.000287             unite#custom_action()
    4   0.000260   0.000101  unite#loaded_sources_list()
    1   0.000177   0.000109  unite#gather_candidates()

FUNCTIONS SORTED ON SELF TIME
count  total (s)   self (s)  function
  458   0.059396   0.031909  unite#util#truncate()
  687   0.046003   0.014722  unite#util#wcswidth()
  229   0.066492   0.014633  unite#util#truncate_smart()
    1              0.005714  unite#mappings#define_default_mappings()
    4   0.005092   0.001241  unite#sources#file_mru#_append()
    1   0.001308   0.001053  unite#sources#outline#get_outline_info()
    5   0.001204   0.000979  unite#sources#directory_mru#_append()
    2              0.000743  unite#sources#tags#_save_last_tagfiles()
    4              0.000611  unite#sources#buffer#_append()
    1   0.409791   0.000506  unite#start()
    2              0.000387  unite#set_substitute_pattern()
   14              0.000327  unite#util#is_win()
    6              0.000305  unite#util#set_default()
    3              0.000287  unite#custom_action()
   13   0.000568   0.000269  unite#util#substitute_path_separator()
    1   0.100477   0.000237  unite#redraw_candidates()
    1   0.000177   0.000109  unite#gather_candidates()
    4   0.000260   0.000101  unite#loaded_sources_list()
    1   0.000152   0.000089  unite#redraw_status()
    4              0.000072  unite#sources#outline#alias()
</pre>


すべての候補がマルチバイト文字を含む場合には時間コストは改善しませんが、ASCII only な候補の比率が増えるに従いこちらが有利になります。unite の場合、大抵の source で高速化が見込めるのではないでしょうか。
