### PR TITLE
Add the "../" option description 

### DIFF
--- a/doc/unite.txt
+++ b/doc/unite.txt
@@ -173,6 +173,7 @@ COMMANDS 					*unite-commands*
 						*unite-options-input*
 		-input={input-text}
 		Specifies an initial narrowing text. The default value is ''.
+		You can use "-input=." to show the "../" candidate. 
 
 						*unite-options-prompt*
 		-prompt={prompt-text}


### PR DESCRIPTION
add the "../" option description , if the code for showing parent doesn't change anymore in the future.

**Reason:** 
I could not find the parent candidate  **"../"** for a several  weeks ...

until I checked the code and saw this:

```
if a:context.input =~ '\.$' && isdirectory(l:parent . '..')
```

So, I understand that I should use -input=. to get the **../** candidate.
I add an option ,but don't know if this is the final code of showing **../** candidate
