### PR TITLE
Fix window size restoration on auto previewing.

### DIFF
--- a/autoload/unite.vim
+++ b/autoload/unite.vim
@@ -1426,8 +1426,10 @@ function! s:on_cursor_moved()  "{{{
     " Restore window size.
     let l:context = unite#get_context()
     if winnr('$') != 1
-      if l:context.vertical && winwidth(winnr()) != l:context.winwidth
-        execute 'vertical resize' l:context.winwidth
+      if l:context.vertical
+        if winwidth(winnr()) != l:context.winwidth
+          execute 'vertical resize' l:context.winwidth
+        endif
       elseif winheight(winnr()) != l:context.winwidth
         execute 'resize' l:context.winheight
       endif


### PR DESCRIPTION
let g:unite_enable_split_vertically = 1

な設定のときに -auto-preview を使うと、preview window の表示と同時に以下のような状態になりました↓

<a href="http://f.hatena.ne.jp/h1mesuke/20110514162926"><img src="http://img.f.hatena.ne.jp/images/fotolife/h/h1mesuke/20110514/20110514162926.png" alt="20110514162926"></a>

調べてみたところ、s:on_cursor_moved() のウィンドウサイズを復元するところに、
if の条件式がおかしなところがあったので直しました。

上の画像のようになる原因は vertical なのに horizontal の場合の復元をやっているからでした。
