### PR TITLE
persist_jump アクションの追加

### DIFF
--- a/autoload/unite/kinds/jump_list.vim
+++ b/autoload/unite/kinds/jump_list.vim
@@ -34,6 +34,9 @@ else
   let g:unite_kind_jump_list_after_jump_scroll =
         \ min([max([0, g:unite_kind_jump_list_after_jump_scroll]), 100])
 endif
+if !exists('g:unite_kind_jump_list_persist_jump_blink_time')
+  let g:unite_kind_jump_list_persist_jump_blink_time = "250m"
+endif
 "}}}
 
 function! unite#kinds#jump_list#define()"{{{
@@ -71,6 +74,22 @@ let s:kind.action_table.preview = {
       \ }
 function! s:kind.action_table.preview.func(candidate)"{{{
   pedit +call\ s:jump(a:candidate,1) `=a:candidate.action__path`
+endfunction"}}}
+
+let s:kind.action_table.persist_jump = {
+      \ 'description' : 'persistent jump',
+      \ 'is_quit'     : 0,
+      \ }
+function! s:kind.action_table.persist_jump.func(candidate)"{{{
+  wincmd p
+  call s:kind.action_table.open.func([a:candidate])
+  if g:unite_kind_jump_list_persist_jump_blink_time
+    normal! ^v$
+    redraw!
+    exe "sleep " . g:unite_kind_jump_list_persist_jump_blink_time
+    normal! v
+  endif
+  wincmd p
 endfunction"}}}
 
 if globpath(&runtimepath, 'autoload/qfreplace.vim') != ''


### PR DESCRIPTION
なんか、gist のやつと全然かわりませんでしたが。。
jump_list じゃないと line がない、というのはその通りですね。
こういうのは keymap を設定して使いたいのですが、 特定の source or kind のみで有効になる keymap の定義の仕方はがわからなかった。
私は下記のように u を使ってますが、全 unite で有効になってしまうのがイケテないんですよね。

```
function! s:unite_my_settings()
    nnoremap <silent><buffer><expr> u unite#do_action('persist_jump')
endfunction
```
