### PR TITLE
<Plug>(unite_delete_backward_path) を行末より後ろにいた場合でも動くように (+virtualedit)

### DIFF
--- a/autoload/unite/mappings.vim
+++ b/autoload/unite/mappings.vim
@@ -297,8 +297,11 @@ function! s:restart()"{{{
   call unite#start(l:sources, l:context)
 endfunction"}}}
 function! s:delete_backward_path()"{{{
-  let l:input = getline(unite#get_current_unite().prompt_linenr)[len(unite#get_current_unite().prompt):]
-  return repeat("\<C-h>", len(matchstr(l:input, '[^/]*.$')))
+  let l:prompt   = unite#get_current_unite().prompt
+  let l:input    = getline(unite#get_current_unite().prompt_linenr)[len(l:prompt):]
+  let l:startcol = match(l:input, '[^/]*.$') + 1 + len(l:prompt)
+  let l:endcol   = virtcol('.')
+  return repeat("\<C-h>", (l:startcol < l:endcol ? l:endcol - l:startcol : 0))
 endfunction"}}}
 function! s:normal_delete_backward_path()"{{{
   let l:modifiable_save = &l:modifiable


### PR DESCRIPTION
`virtcol()`使うようにして行末より後ろにいた時でも正常に動くようになってます。
ここでいう正常とは次のような動作のことです。 (|はカーソルです)

  before: >hoge/fuga/ |
  after: >hoge/

  before: >hoge/fug|a/
  after: >hoge/a/

前はこんな風になってました。

  before: >hoge/fuga/ |
  after: >hoge/f

  before: >hoge/fuga/   |
  after: >hoge/fug
