### PR TITLE
uses relative path to handle a file in file_rec 

### DIFF
--- a/doc/unite.jax
+++ b/doc/unite.jax
@@ -358,10 +358,10 @@ g:unite_no_default_keymappings			*g:unite_no_default_keymappings*
 sourceの変数					*unite-sources-variables*
 
 g:unite_source_file_ignore_pattern		*g:unite_source_file_ignore_pattern*
-		|unite-source-file|, |unite-source-file_rec|の候補に表示しな
-		いファイルの正規表現パターンを指定する。マッチングはファイル
-		のフルパスに対して行われる。この変数が空文字列以外であれば、
-		指定した正規表現で結果をフィルタリングする。
+		|unite-source-file|の候補に表示しないファイルの正規表現パター
+		ンを指定する。マッチングはファイルのフルパスに対して行われる。
+		この変数が空文字列以外であれば、指定した正規表現で結果をフィル
+		タリングする。
 
 		初期値は autoload/unite/sources/file.vim を参照。
 

--- a/doc/unite.txt
+++ b/doc/unite.txt
@@ -360,10 +360,9 @@ SOURCES VARIABLES 				*unite-sources-variables*
 
 g:unite_source_file_ignore_pattern		*g:unite_source_file_ignore_pattern*
 		Specifies a regex pattern for ignoring some specific
-		candidates in which source is file.  This matches on the full
+		candidates in |unite-source-file|.  This matches on the full
 		path of each files.  If the variable isn't empty string, unite
-		filters with the regex pattern on the results.  It depends on
-		|g:unite_enable_ignore_case| to distinguish cases or not.
+		filters with the regex pattern on the results.
 
 		Refer autoload/unite/sources/file.vim about the default value.
 


### PR DESCRIPTION
file_recでファイルを開いたときバッファのファイル名 (`expand('%')で得られるやつ)がフルパスになっていた関係で他のプラギン(例: motemen/git-vim)との連携がうまくいかなかったので、修正してみました。
