### PR TITLE
Remove duplicated [y/N].

### DIFF
--- a/autoload/unite/kinds/file.vim
+++ b/autoload/unite/kinds/file.vim
@@ -528,7 +528,7 @@ function! s:execute_command(command, candidate)"{{{
   let dir = unite#util#path2directory(a:candidate.action__path)
   " Auto make directory.
   if !isdirectory(dir) && unite#util#input_yesno(
-        \   printf('"%s" does not exist. Create? [y/N]', dir))
+        \   printf('"%s" does not exist. Create?', dir))
     call mkdir(iconv(dir, &encoding, &termencoding), 'p')
   endif
 


### PR DESCRIPTION
file source にて新規ディレクトリを作成するときの確認用プロンプトが

```
"/path/to/file" does not exist. Create? [y/N] [yes/no] :
```

みたいになっていたので、[y/N] の方を取り除きました。
