### PR TITLE
Hi Shougo, a tiny patch to remove a disturbing prompt. Thank you for your great plugins !

### DIFF
--- a/plugin/unite/history_yank.vim
+++ b/plugin/unite/history_yank.vim
@@ -35,7 +35,7 @@ if exists('g:unite_source_history_yank_enable')
       \ && g:unite_source_history_yank_enable
   augroup plugin-unite-history-yank
     autocmd!
-    autocmd CursorMoved * call unite#sources#history_yank#_append()
+    autocmd CursorMoved * silent call unite#sources#history_yank#_append()
   augroup END
 endif
 


### PR DESCRIPTION
The function called by autocmd on CursorMoved is generating a prompt (Press ENTER or type command to continue) on certain occasion (search, ex command, ...)
