### PR TITLE
Session source: no need to modify filename with `:r`

### DIFF
--- a/autoload/unite/sources/session.vim
+++ b/autoload/unite/sources/session.vim
@@ -157,7 +157,7 @@ function! s:source.gather_candidates(args, context)"{{{
   let sessions = split(glob(g:unite_source_session_path.'/*'), '\n')
 
   let candidates = map(copy(sessions), "{
-        \ 'word' : fnamemodify(v:val, ':t:r'),
+        \ 'word' : fnamemodify(v:val, ':t'),
         \ 'kind' : 'file',
         \ 'action__path' : v:val,
         \ 'action__directory' : unite#util#path2directory(v:val),


### PR DESCRIPTION
I have session names (generated by other plugin) like:
1. -home-bootleq-.bundler-ruby-1.8-.git-c2a5cfee5210-git--master
2. -opt-ruby-lib-ruby-gems-1.8-gems-kaminari-0.12.4

Their "word"s shown as:
1. -home-bootleq-.bundler-ruby-1.8-
2. -opt-ruby-lib-ruby-gems-1.8-gems-kaminari-0.12

That's not good, and since session files don't have extensions anyway,
I think it's reasonable to keep the file extension unchanged.
