### PR TITLE
tiny bug fix for unite_source_file_mru_ignore_pattern

### DIFF
--- a/autoload/unite/sources/file_mru.vim
+++ b/autoload/unite/sources/file_mru.vim
@@ -54,16 +54,13 @@ function! unite#sources#file_mru#define()"{{{
   return s:source
 endfunction"}}}
 function! unite#sources#file_mru#_append()"{{{
-"    call Dfunc("file_mru#_append(" . ")")
   let path = unite#util#substitute_path_separator(
         \ simplify(resolve(expand('%:p'))))
 
-"  call Decho("path: " . path)
   " Append the current buffer to the mru list.
   if !s:is_exists_path(path) || &buftype =~ 'help'
   \   || (g:unite_source_file_mru_ignore_pattern != ''
   \      && path =~# g:unite_source_file_mru_ignore_pattern)
-"  call Dret("file_mru#_append(" . ")" . ": early return!")
     return
   endif
 
@@ -82,7 +79,6 @@ function! unite#sources#file_mru#_append()"{{{
   endif
 
   call s:save()
-"  call Dret("file_mru#_append(" . ")")
 endfunction"}}}
 
 let s:source = {


### PR DESCRIPTION
Please check the diff. it is easy to say with colorful highlight. 

By the way, what does the `rec` in `file_rec` stands for? I cannot figure it out...
