### PR TITLE
fix documents' tag duplication

### DIFF
--- a/doc/unite.jax
+++ b/doc/unite.jax
@@ -996,7 +996,7 @@ unite#get_candidates({sources}, [, {context}])			*unite#get_candidates()*
 		Note: sourceのmax_candidatesオプションは無視される。
 
 unite#do_candidates_action({action-name}, {candidates}, [, {context}])
-								*unite#get_candidates()*
+								*unite#do_candidates_action()*
 		指定した{candidates}を利用して、{action-name}を実行する。unite
 		バッファは生成されない。uniteバッファが存在することを前提として
 		いるactionによってはうまく動作しないかもしれない。

--- a/doc/unite.txt
+++ b/doc/unite.txt
@@ -1012,7 +1012,7 @@ unite#get_candidates({sources}, [, {context}])	*unite#get_candidates()*
 		Note: Ignore sources max_candidates option.
 
 unite#do_candidates_action({action-name}, {candidates}, [, {context}])
-						*unite#get_candidates()*
+						*unite#do_candidates_action()*
 		Do {action-name} with {candidates}. Does not create unite
 		buffer.  This function may not work in some actions.
 		Note: To get candidates, use |unite#get_candidates()|.


### PR DESCRIPTION
ドキュメント内で *unite#get_candidates()* というタグが重複していました。
unite#do_candidates_action() を追加したときに、コピペをミスってしまったのだと思います。
