### PR TITLE
Change feedkey to avoid error bells

### DIFF
--- a/autoload/unite.vim
+++ b/autoload/unite.vim
@@ -2357,7 +2357,7 @@ function! s:on_cursor_hold_i()  "{{{
 
   if unite.is_async
     " Ignore key sequences.
-    call feedkeys("\<C-r>\<ESC>", 'n')
+	call feedkeys("a\<BS>",'n')
   endif
 endfunction"}}}
 function! unite#_on_cursor_hold()  "{{{


### PR DESCRIPTION
In MacVim, <C-R><ESC> causes error bells.
