### PR TITLE
auto_resizeがオンの時に初回入力時のカーソルの位置がずれる挙動の修正

### DIFF
--- a/autoload/unite.vim
+++ b/autoload/unite.vim
@@ -2261,7 +2261,7 @@ function! unite#_resize_window() "{{{
     let max_len = unite.prompt_linenr + len(unite.candidates)
     execute 'resize' min([max_len, context.winheight])
     normal! zb
-    if mode() == 'i' && col('.') == (col('$') - 1)
+    if mode() ==# 'i' && col('.') == (col('$') - 1)
       startinsert!
     endif
   elseif context.vertical


### PR DESCRIPTION
on_cursor_hold_iでunite#redrawした時にauto_resizeがオンの場合、行末でinsert modeの場合は必ずカーソル位置が戻ってしまう挙動を修正しました。
