### PR TITLE
fix entry check at s:custom.source in unite#custom_source().

### DIFF
--- a/autoload/unite.vim
+++ b/autoload/unite.vim
@@ -126,7 +126,7 @@ function! unite#undef_custom_action(kind, name)"{{{
 endfunction"}}}
 function! unite#custom_source(source_name, option_name, value)"{{{
   for key in split(a:source_name, '\s*,\s*')
-    if has_key(s:custom.source, key)
+    if !has_key(s:custom.source, key)
       let s:custom.source[key] = {}
     endif
 


### PR DESCRIPTION
57367d00dce113efeee38ed99c9151c3127016b3 で新設された unite#custom_source() で s:custom.source の key 探索時の判定が逆だと思いましたので修正しました。
