### PR TITLE
jump sourceでジャンプ先が候補に表示されないことがある

### DIFF
--- a/autoload/unite/sources/jump.vim
+++ b/autoload/unite/sources/jump.vim
@@ -58,7 +58,7 @@ function! s:source.gather_candidates(args, context)"{{{
     let path = file_text
     let bufnr = bufnr(file_text)
     if empty(lines)
-      if getline(linenr) ==# file_text
+      if stridx(join(split(getline(linenr))), file_text) == 0
         let lines = [file_text]
         let path = bufname('%')
         let bufnr = bufnr('%')


### PR DESCRIPTION
:jump コマンドの一覧に表示されても、:Unite jump では表示されない場合があります。
具体的には、:jump の file/text の欄に行の中身が表示され、さらに行頭以外に2つ以上の連続するスペースが含まれる行が表示されません。

理由は、sources/jump.vim で、:jump の出力結果を split して行の部分を join していますが、この時点で2つ以上の連続するスペースが消えてしまっているからです。
この問題を、 getline で取得した行も同じように split & join することで対処しました。

また、:jump の出力は長い行を途中でカットするので、文字列は先頭一致で比較するようにしてあります。
