### PR TITLE
unite-process without confirming

### DIFF
--- a/autoload/unite/sources/process.vim
+++ b/autoload/unite/sources/process.vim
@@ -28,6 +28,8 @@ let s:save_cpo = &cpo
 set cpo&vim
 
 " Variables  "{{{
+call unite#util#set_default(
+      \ 'g:unite_source_process_enable_confirm', 1)
 "}}}
 
 function! unite#sources#process#define() "{{{
@@ -128,14 +130,16 @@ function! s:source.action_table.unite__new_candidate.func(candidate) "{{{
 endfunction"}}}
 
 function! s:kill(signal, candidates) "{{{
-  if !unite#util#input_yesno(
-        \ 'Really send the ' . a:signal .' signal to the processes?')
-    redraw
-    echo 'Canceled.'
-    return
-  endif
+  if g:unite_source_process_enable_confirm
+    if !unite#util#input_yesno(
+          \ 'Really send the ' . a:signal .' signal to the processes?')
+      redraw
+      echo 'Canceled.'
+      return
+    endif
 
-  redraw
+    redraw
+  endif
 
   for candidate in a:candidates
     call unite#util#system(unite#util#is_windows() ?

--- a/doc/unite.txt
+++ b/doc/unite.txt
@@ -571,6 +571,13 @@ g:unite_source_history_yank_file	*g:unite_source_history_yank_file*
 
 		The default value is |g:unite_data_directory|; '/history_yank'
 
+g:unite_source_process_enable_confirm	*g:unite_source_process_enable_confirm*
+		When you send a signal to a process via |unite-source-process|
+		such as KILL, Vim will ask you if you really want to do that
+		if this variable is 1.
+
+		The default value is 1.
+
 KINDS VARIABLES					*unite-kinds-variables*
 
 g:unite_kind_jump_list_after_jump_scroll
@@ -2907,6 +2914,7 @@ CHANGELOG					*unite-changelog*
 
 2013-02-07
 - Fixed start action.
+- Added g:unite_source_process_enable_confirm option.
 
 2013-02-03
 - Improved unite menu behavior.


### PR DESCRIPTION
unite-processでプロセスをkillしたりするときに必ずVimをブロックしてyes/noを確認してきますが、意図的にこれを無確認でkillなどできるようにするためのオプションを追加してみました。`g:unite_source_process_enable_confirm`です。

デフォルト、つまりユーザが何も指定しなかったときの上記の値は1で、つまりこれまでの実装と全く同じ挙動です。ユーザが明示的に0を指定したときのみ確認をスキップします。

(僕の環境でprocess管理とimmediatelyを組み合わせたのを使っていて、どうしても確認をスキップしたかったのです)
