### PR TITLE
unite-grep： Target にディレクトリを指定した場合に、 候補ファイルを開くことができない

### DIFF
--- a/autoload/unite/sources/grep.vim
+++ b/autoload/unite/sources/grep.vim
@@ -247,6 +247,11 @@ function! s:source.async_gather_candidates(args, context) "{{{
           \ '[v:val, split(v:val[2:], ":")]')
   endif
 
+  let cwd = getcwd()
+  if isdirectory(a:context.source__directory)
+    lcd `=a:context.source__directory`
+  endif
+
   if a:context.source__ssh_path != ''
     " Use ssh command.
     let [hostname, port, path] = unite#sources#ssh#parse_path(
@@ -276,6 +281,8 @@ function! s:source.async_gather_candidates(args, context) "{{{
 
     call add(_, dict)
   endfor
+
+  lcd `=cwd`
 
   return _
 endfunction "}}}


### PR DESCRIPTION
252行目で lcd した後での、 285行目 isdirectory() では正しく判定できないようです。
そのため、常に元のディレクトリに戻るようにしています。
