### PR TITLE
Add settings of grep command encoding.

### DIFF
--- a/autoload/unite/sources/grep.vim
+++ b/autoload/unite/sources/grep.vim
@@ -35,6 +35,7 @@ call unite#util#set_default('g:unite_source_grep_ignore_pattern',
       \'\~$\|\.\%(o\|exe\|dll\|bak\|sw[po]\)$\|'.
       \'\%(^\|/\)\.\%(hg\|git\|bzr\|svn\)\%($\|/\)\|'.
       \'\%(^\|/\)tags\%(-\a*\)\?$')
+call unite#util#set_default('g:unite_source_grep_encoding', 'char')
 "}}}
 
 function! unite#sources#grep#define() "{{{
@@ -243,7 +244,7 @@ function! s:source.async_gather_candidates(args, context) "{{{
   endif
 
   let candidates = map(stdout.read_lines(-1, 100),
-          \ "unite#util#iconv(v:val, 'char', &encoding)")
+          \ "unite#util#iconv(v:val, g:unite_source_grep_encoding, &encoding)")
   if variables.default_opts =~ '^-[^-]*l'
         \ || a:context.source__extra_opts =~ '^-[^-]*l'
     let candidates = map(filter(candidates,

--- a/doc/unite.txt
+++ b/doc/unite.txt
@@ -702,6 +702,11 @@ g:unite_source_grep_search_word_highlight
 
 		The default value is "Search".
 
+g:unite_source_grep_encoding			*g:unite_source_grep_encoding*
+		Set output encoding of grep command.
+
+		The default value is "char".
+
 g:unite_source_vimgrep_search_word_highlight
 				*g:unite_source_vimgrep_search_word_highlight*
 		Specify the search word highlight.


### PR DESCRIPTION
単純に自分の設定ミスなのかもしれませんが、それらしい設定が探ってもわかりませんでした。
概ねcp932とutf-8が混在してしまうWindows用のオプションになりますが、
stdoutのencodeを指定できるようにしました。

Git添付のgrep.exeはコマンドプロンプト上ではcp932に変換して出力しているようですが、
パイプ等で繋げたりした場合そのまま出力されてしまうようです。
で、それをcp932として読み込んでいた為、本来文字化ける筈のcp932ファイルの結果が正常表示されて、
utf-8ファイルの結果だと文字化けるということになってました。

jvgrepに至っては内部でencode判断してutf-8に変換して出力してしまうので、
あらゆるencodeのファイルの結果で文字化けるという状況になってました。

---

専用オプションではなくvimprocで使われてる `g:stdoutencoding` を参照した方が良いですかね？
