### PR TITLE
候補の初期表示数を winheight(0) にする

### DIFF
--- a/autoload/unite/candidates.vim
+++ b/autoload/unite/candidates.vim
@@ -107,9 +107,7 @@ function! unite#candidates#gather(...) "{{{
   if is_gather_all
     let unite.candidates_pos = len(unite.candidates)
   elseif unite.context.is_redraw || unite.candidates_pos == 0
-    let height = unite.context.no_split ?
-          \ winheight(0) : unite.context.winheight
-    let unite.candidates_pos = height
+    let unite.candidates_pos = winheight(0)
   endif
 
   let candidates = unite#init#_candidates(


### PR DESCRIPTION
候補の初期表示数は -no-split でない場合、 g:unite_winheight の値が使われます。
通常は問題ないのですが、 -vertical で起動した場合も g:unite_winheight で切られてしまいます。
実際には表示できる行がまだあるのに g:unite_winheight 分までしか表示されません。

特に、 unite-outline を常時表示して確認しつつ文章を書くときなどは
- 一度 unite バッファにカーソルを移動してかつ下にカーソルを移動しないと全体が再描画されない
- 保存して再描画されるタイミングで g:unite_winheight の行数分しか表示されない

という点が特に困ります。

回避方法としては

```
-winheight=winheight(0)
```

をパラメータに追加する方法はあります。

修正箇所があっているのか自身がありませんが・・・意図としては上記のとおりです。
