### PR TITLE
Add utf-8-mac conversion to get_vimfiler_candidates

### DIFF
--- a/autoload/unite/start.vim
+++ b/autoload/unite/start.vim
@@ -267,6 +267,18 @@ function! unite#start#get_vimfiler_candidates(sources, ...) "{{{
     let context.unite__is_interactive = 0
 
     let candidates = s:get_candidates(a:sources, context)
+
+    " convert utf-8-mac to utf-8
+    if has('mac') && has('iconv')
+      for item in candidates
+        let item.action__path = iconv(item.action__path, "utf-8-mac", "utf-8")
+        let item.action__directory = iconv(item.action__directory, "utf-8-mac", "utf-8")
+        let item.word = iconv(item.word, "utf-8-mac", "utf-8")
+        let item.abbr = iconv(item.abbr, "utf-8-mac", "utf-8")
+        let item.vimfiler__filename = iconv(item.vimfiler__filename, "utf-8-mac", "utf-8")
+        let item.vimfiler__abbr = iconv(item.vimfiler__abbr, "utf-8-mac", "utf-8")
+      endfor
+    endif
   finally
     call unite#set_current_unite(unite_save)
   endtry


### PR DESCRIPTION
Fix this issue https://github.com/Shougo/vimfiler.vim/issues/78

Only Mac iconv can convert utf-8-mac to some encoding.
Mac filesystem converts utf-8 to utf-8-mac automatically.
Because of it, utf-8 filename access has no problem.
