### PR TITLE
Align buffer flags left of the file paths

### DIFF
--- a/autoload/unite/sources/buffer.vim
+++ b/autoload/unite/sources/buffer.vim
@@ -171,11 +171,16 @@ function! s:make_abbr(bufnr, flags) "{{{
     let path = bufname(a:bufnr) == '' ? 'No Name' :
           \ simplify(fnamemodify(bufname(a:bufnr), ':~:.'))
     if a:flags != ''
-      let path .= ' [' . a:flags . ']'
+      " Format flags so that buffer numbers are aligned on the left.
+      " example: '42 a% +' => ' 42 a%+ '
+      "          '3 h +'   => '  3 h+  '
+      let nowhitespace = substitute(a:flags, '\s*', '', 'g')
+      let path = substitute(nowhitespace, '\v(\d+)(.*)',
+            \ '\=printf("%*s %-*s", 3, submatch(1), 4, submatch(2))', 'g') . path
     endif
 
     if filetype != ''
-      let path .= '[' . filetype . ']'
+      let path .= ' [' . filetype . ']'
     endif
   endif
 


### PR DESCRIPTION
This moves the buffer flags to the left of the file paths, and aligns them (compactly--whitespace is removed). This makes it easier to see the status of the open buffers.

**Layout after this commit:**
![after](https://f.cloud.github.com/assets/1359421/1186921/3da0464a-2334-11e3-91d0-f86c40e28187.png)

**Layout before this commit:**
![before](https://f.cloud.github.com/assets/1359421/1186920/30ed9024-2334-11e3-9264-ed8563a39e33.png)
