### PR TITLE
Fix guicmd execution when filename includes single quote

### DIFF
--- a/autoload/unite/kinds/guicmd.vim
+++ b/autoload/unite/kinds/guicmd.vim
@@ -54,7 +54,7 @@ function! s:kind.action_table.execute.func(candidate) "{{{
 
   let cmdline = unite#util#is_windows() ?
         \ join(map(args, '"\"".v:val."\""')) :
-        \ args[0] . ' ' . join(map(args[1:], "''''.v:val.''''"))
+        \ args[0] . ' ' . join(map(args[1:], "shellescape(v:val)"))
 
   if unite#util#is_windows()
     let cmdline = unite#util#iconv(cmdline, &encoding, 'char')


### PR DESCRIPTION
Vimfiler failed to execute a file, when its filename includes single quote.
This patch fixes it.

FYI. My system environments is Mac (Mountain Lion) & MacVim-kaoriya v7.4.22.
