### PR TITLE
use noautocmd to suppress side effects (for example, lcd in BufEnter)

### DIFF
--- a/autoload/unite/kinds/file.vim
+++ b/autoload/unite/kinds/file.vim
@@ -853,9 +853,9 @@ function! unite#kinds#file#do_rename(old_filename, new_filename) "{{{
 
       " Buffer rename.
       let bufnr_save = bufnr('%')
-      execute 'buffer' bufnr
+      noautocmd execute 'buffer' bufnr
       saveas! `=new_filename`
-      execute 'buffer' bufnr_save
+      noautocmd execute 'buffer' bufnr_save
     endif
 
     if rename(old_filename, new_filename)


### PR DESCRIPTION
BufEnterでlcdするような設定があると, リネームが失敗します.
これを修正しました.
