### PR TITLE
Fixed unite#util#glob()

### DIFF
--- a/autoload/unite/util.vim
+++ b/autoload/unite/util.vim
@@ -243,7 +243,7 @@ function! unite#util#glob(pattern, ...) "{{{
   endif
 
   " let is_force_glob = get(a:000, 0, 0)
-  let is_force_glob = get(a:000, 0, 1)
+  let is_force_glob = get(a:000, 1, 1)
 
   if !is_force_glob && (a:pattern =~ '\*$' || a:pattern == '*')
         \ && unite#util#has_vimproc() && exists('*vimproc#readdir')


### PR DESCRIPTION
VimFilerで\で始まる共有サーバが扱えないところを調べていたらここに行き着きました。
is_force_globに入れる値が間違っているようです。
