### PR TITLE
Fix logic of loading migemo path

### DIFF
--- a/autoload/unite/filters/matcher_migemo.vim
+++ b/autoload/unite/filters/matcher_migemo.vim
@@ -72,7 +72,7 @@ function! s:search_dict2(name)
           \ '/usr/local/share/'.a:name,
           \ '/usr/share/'.a:name,
           \ ]
-      if !filereadable(path)
+      if filereadable(path)
         let dict = path
       endif
     endfor


### PR DESCRIPTION
hi Shougoさん

mathcer_migemo におけるmigemoの辞書を探す関数の条件分岐が間違ってるようです。

`filereadable`なら、そのパスをdict変数に代入すべきなはずです。
