### PR TITLE
Move default cd variables into cdable kind

### DIFF
--- a/autoload/unite/kinds/cdable.vim
+++ b/autoload/unite/kinds/cdable.vim
@@ -27,6 +27,10 @@
 let s:save_cpo = &cpo
 set cpo&vim
 
+" Variables {{{
+call unite#util#set_default('g:unite_kind_openable_cd_command', 'cd')
+call unite#util#set_default('g:unite_kind_openable_lcd_command', 'lcd')
+" }}}
 function! unite#kinds#cdable#define() "{{{
   return s:kind
 endfunction"}}}

--- a/autoload/unite/kinds/openable.vim
+++ b/autoload/unite/kinds/openable.vim
@@ -29,8 +29,6 @@ set cpo&vim
 
 " Variables  "{{{
 call unite#util#set_default('g:unite_kind_openable_persist_open_blink_time', '250m')
-call unite#util#set_default('g:unite_kind_openable_cd_command', 'cd')
-call unite#util#set_default('g:unite_kind_openable_lcd_command', 'lcd')
 "}}}
 function! unite#kinds#openable#define() "{{{
   return s:kind


### PR DESCRIPTION
I think this is better, otherwise you will have to call set_default for cd and lcd command for every source that only use the cdable kind.
