### PR TITLE
Difference of variable between doc and codes

### DIFF
--- a/doc/unite.txt
+++ b/doc/unite.txt
@@ -442,8 +442,8 @@ g:unite_abbr_highlight				*g:unite_abbr_highlight*
 
 		The default value is "Normal".
 
-				*g:unite_enable_use_short_source_names*
-g:unite_enable_use_short_source_names
+				*g:unite_enable_short_source_names*
+g:unite_enable_short_source_names
 		If this variable is 1, unite buffer will show short source
 		names.
 


### PR DESCRIPTION
`g:unite_enable_use_short_source_names` as defined in doc is not used in source codes.

Actually, does it refer to `g:unite_enable_short_source_names`?

I hope to match it with source codes
### Grep results

``` sh
$ git log @ origin/master -1 --pretty="format:%h %s"
b80be50 Improve cursor line behavior

# Used only doc
$ git grep -in unite_enable_use_short_source_names origin/master
origin/master:doc/unite.txt:445:                *g:unite_enable_use_short_source_names*
origin/master:doc/unite.txt:446:g:unite_enable_use_short_source_names

# Used both
$ git grep -in unite_enable_short_source_names origin/master
origin/master:autoload/unite/init.vim:75:    let context.short_source_names = g:unite_enable_short_source_names
origin/master:doc/unite.txt:238:    "let g:unite_enable_short_source_names = 1
origin/master:plugin/unite.vim:80:let g:unite_enable_short_source_names =
origin/master:plugin/unite.vim:81:      \ get(g:, 'unite_enable_short_source_names', 0)
```
