### PR TITLE
Remove ESC mapping in example config

### DIFF
--- a/doc/unite.txt
+++ b/doc/unite.txt
@@ -254,7 +254,6 @@ More advanced configuration example:
 	function! s:unite_my_settings()"{{{
 	  " Overwrite settings.
 
-	  nmap <buffer> <ESC>      <Plug>(unite_exit)
 	  imap <buffer> jj      <Plug>(unite_insert_leave)
 	  "imap <buffer> <C-w>     <Plug>(unite_delete_backward_path)
 


### PR DESCRIPTION
It breaks arrow navigation in normal mode in unite. It takes me some time to understand where is problem, when arrow keys stop working. I think it will be better if this mapping will be marked as dangerous, or completly removed from documentation.
