### PR TITLE
Stop Unite from overriding `startinsert` autocommands with `stopinsert`

### DIFF
--- a/autoload/unite/view.vim
+++ b/autoload/unite/view.vim
@@ -597,7 +597,6 @@ function! unite#view#_quit(is_force, ...)  "{{{
     endif
   else
     redraw
-    stopinsert
   endif
 
   " Restore unite.


### PR DESCRIPTION
I have this autocmd for vimshell: `au BufEnter [vimshell]* startinsert! | normal! G$`.
Without this change Unite overrules the autocmd.
