### PR TITLE
add g:unite_kind_file_vertical_preview

### DIFF
--- a/autoload/unite/kinds/file.vim
+++ b/autoload/unite/kinds/file.vim
@@ -26,6 +26,12 @@
 let s:save_cpo = &cpo
 set cpo&vim
 
+" Variables  "{{{
+if !exists('g:unite_kind_file_vertical_preview')
+  let g:unite_kind_file_vertical_preview = 0
+endif
+"}}}
+
 " Global options definition. "{{{
 call unite#util#set_default(
       \ 'g:unite_kind_file_delete_file_command',
@@ -99,9 +105,17 @@ function! s:kind.action_table.preview.func(candidate) "{{{
         \ a:candidate.action__path))
   if filereadable(a:candidate.action__path)
     " If execute this command, unite.vim will be affected by events.
-    noautocmd silent execute 'pedit!'
-          \ fnameescape(a:candidate.action__path)
-
+    if g:unite_kind_file_vertical_preview
+      let unite_winwidth = winwidth(0)
+      noautocmd silent execute 'vert pedit!'
+            \ fnameescape(a:candidate.action__path)
+      wincmd P
+      let target_winwidth = (unite_winwidth + winwidth(0)) / 2
+      execute 'wincmd p | vert resize ' . target_winwidth
+    else
+      noautocmd silent execute 'pedit!'
+            \ fnameescape(a:candidate.action__path)
+    endif
     let prev_winnr = winnr('#')
     let winnr = winnr()
     wincmd P
@@ -110,13 +124,13 @@ function! s:kind.action_table.preview.func(candidate) "{{{
     execute prev_winnr.'wincmd w'
     execute winnr.'wincmd w'
   endif
-
   if !buflisted
     call unite#add_previewed_buffer_list(
         \ bufnr(unite#util#escape_file_searching(
         \       a:candidate.action__path)))
   endif
 endfunction"}}}
+
 
 let s:kind.action_table.mkdir = {
       \ 'description' : 'make this directory and parents directory',

--- a/doc/unite.txt
+++ b/doc/unite.txt
@@ -854,6 +854,14 @@ g:unite_kind_jump_list_after_jump_scroll
 
 		The default value is 25.
 
+g:unite_kind_file_vertical_preview		*g:unite_kind_file_vertical_preview*
+		If this variable is 1, Unite will open the preview window
+		(when executing the file preview action) vertically rather than
+		horizontally. It will take up half the width of the current
+		Unite buffer.
+
+		The default value is 0.
+
 			*g:unite_kind_openable_persist_open_blink_time*
 g:unite_kind_openable_persist_open_blink_time
 		The amount of blink time after "persist_open" action from


### PR DESCRIPTION
This adds a configuration option to open the preview window with the
file kind in a vertical split.
