### PR TITLE
Kind jump_list: keepjumps when open buffer

### DIFF
--- a/autoload/unite/kinds/jump_list.vim
+++ b/autoload/unite/kinds/jump_list.vim
@@ -278,10 +278,10 @@ function! s:open(candidate) "{{{
   let bufnr = s:get_bufnr(a:candidate)
   if bufnr != bufnr('%')
     if has_key(a:candidate, 'action__buffer_nr')
-      silent execute 'buffer' bufnr
+      silent execute 'keepjumps buffer' bufnr
     else
       call unite#util#smart_execute_command(
-            \ 'edit!', unite#util#substitute_path_separator(
+            \ 'keepjumps edit!', unite#util#substitute_path_separator(
             \   fnamemodify(a:candidate.action__path, ':~:.')))
     endif
   endif


### PR DESCRIPTION
When jump_list.open invoked,
1. Open the file
2. Jump to specified line

and two positions pushed into jumplist. This is undesired behaviour.
