### PR TITLE
Fix group post_filter has_key check on groups

### DIFF
--- a/autoload/unite/candidates.vim
+++ b/autoload/unite/candidates.vim
@@ -385,7 +385,7 @@ function! unite#candidates#_group_post_filters(candidates) "{{{
   let groups = {}
   for i in range(0, len(a:candidates) - 1)
     let group = a:candidates[i].group
-    if has_key(groups, 'group')
+    if has_key(groups, group)
       call add(groups[group].indexes, i)
     else
       let groups[group] = { 'index' : i, 'indexes' : [i] }

--- a/vest/test-sorter.vim
+++ b/vest/test-sorter.vim
@@ -34,11 +34,13 @@ Context Source.run()
   It tests group feature.
     ShouldEqual unite#candidates#_group_post_filters([
           \ {'word' : 'foo', 'group' : 'bar'},
-          \ {'word' : 'bar', 'group' : 'baz'}]), [
+          \ {'word' : 'bar', 'group' : 'baz'},
+          \ {'word' : 'qux', 'group' : 'baz'}]), [
           \ {'word' : 'bar', 'is_dummy' : 1},
           \ {'word' : 'foo', 'group' : 'bar'},
           \ {'word' : 'baz', 'is_dummy' : 1},
           \ {'word' : 'bar', 'group' : 'baz'},
+          \ {'word' : 'qux', 'group' : 'baz'},
           \]
   End
 End


### PR DESCRIPTION
The group post_filter checks for a key named 'group' instead of the
value of the group variable. When there are multiple candidates for a
group, they overwrite each other and only keep the most recent one.

I also updated test-sorter to use multiple candidates for a group. The
test wasn't failing because it only had one candidate for each group.
