### PR TITLE
add g:unite_source_file_show_full_path variable

### DIFF
--- a/autoload/unite/sources/file.vim
+++ b/autoload/unite/sources/file.vim
@@ -31,6 +31,7 @@ let s:is_windows = unite#util#is_windows()
 " Variables  "{{{
 call unite#util#set_default('g:unite_source_file_ignore_pattern',
       \'\%(^\|/\)\.\.\?$\|\~$\|\.\%(o|exe|dll|bak|DS_Store|pyc|zwc|sw[po]\)$')
+call unite#util#set_default('g:unite_source_file_show_full_path', 1)
 "}}}
 
 function! unite#sources#file#define() "{{{
@@ -286,6 +287,10 @@ function! unite#sources#file#create_file_dict(file, is_relative_path, ...) "{{{
         \ 'word' : a:file, 'abbr' : a:file,
         \ 'action__path' : a:file,
         \}
+
+  if !g:unite_source_file_show_full_path
+    let dict.abbr = fnamemodify(a:file, ':t')
+  endif
 
   let dict.vimfiler__is_directory =
         \ isdirectory(dict.action__path)

--- a/doc/unite.txt
+++ b/doc/unite.txt
@@ -530,6 +530,12 @@ g:unite_source_file_ignore_pattern	*g:unite_source_file_ignore_pattern*
 
 		Refer to autoload/unite/sources/file.vim for the default value.
 
+g:unite_source_file_show_full_path	*g:unite_source_file_show_full_path*
+		If true, display the full path to the file candidates in the
+		Unite buffer. If false, display just the filename.
+
+		The default value is 1.
+
 g:unite_source_bookmark_directory	*g:unite_source_bookmark_directory*
 		Specify the directory where |unite-source-bookmark| writes
 		its bookmarks.


### PR DESCRIPTION
Add a variable, `g:unite_source_file_show_full_path` to allow configuration of how candidates are displayed for the `file` source. When true, set `abbr` attribute of a file candidate to the full path to the file (this is the current behavior, and the default value for the variable). When false, set `abbr` to just the filename.
