### PR TITLE
Skip clipboard history item if it matches unnamed register

### DIFF
--- a/autoload/unite/sources/history_yank.vim
+++ b/autoload/unite/sources/history_yank.vim
@@ -54,7 +54,10 @@ function! unite#sources#history_yank#_append() "{{{
   call s:add_register('"')
 
   if g:unite_source_history_yank_save_clipboard
-    call s:add_register('+')
+    " Skip if registers are identical.
+    if @" != @+
+      call s:add_register('+')
+    endif
   endif
 
   if prev_histories !=# s:yank_histories


### PR DESCRIPTION
There's already a check to skip adding an item to history if it's already in the history, but currently using `clipboard=unnamedplus` adds everything to the history in duplicate.
