### PR TITLE
Fixed narrowing-results by regexp

### DIFF
--- a/autoload/unite/candidates.vim
+++ b/autoload/unite/candidates.vim
@@ -225,10 +225,11 @@ function! s:recache_candidates_loop(context, is_force) "{{{
     let context.is_changed = a:context.is_changed
     let context.is_invalidate = source.unite__is_invalidate
     let context.is_list_input = a:context.is_list_input
-    let context.input_list = map(split(context.input, '\\\@<! ', 1),
-          \ "substitute(v:val, '\\\\\\ze.', '', 'g')")
-    let context.path = get(filter(copy(context.input_list),
-        \         "v:val !~ '^[!:]'"), 0, '')
+    let context.input_list = split(context.input, '\\\@<! ', 1)
+    let context.path = get(filter(
+          \ map(copy(context.input_list),
+          \         "substitute(v:val, '\\\\\\ze.', '', 'g')"),
+          \ "v:val !~ '^[!:]'"), 0, '')
     let context.unite__max_candidates =
           \ (unite.disabled_max_candidates ? 0 : source.max_candidates)
 


### PR DESCRIPTION
2ecc0a2310 プロンプト入力値からバックスラッシュを除去しているため、
grep や line などの matcher_regexp を使う source で、絞り込みに際してほとんどの正規表現が利用できなくなっています。
