### PR TITLE
multi-line problem cause showing prompt on top

### DIFF
--- a/autoload/unite/mappings.vim
+++ b/autoload/unite/mappings.vim
@@ -651,12 +651,13 @@ function! unite#mappings#cursor_up(is_skip_not_matched) "{{{
 
   let num = line('.') - 1
   let cnt = 1
+  let offset = prompt_linenr == 1 ? 1 : 0
   if line('.') == prompt_linenr
     let cnt += 1
   endif
 
   while 1
-    let candidate = get(unite#get_unite_candidates(), num - cnt, {})
+    let candidate = get(unite#get_unite_candidates(), num - offset - cnt, {})
     if num >= cnt && !empty(candidate) && (candidate.is_dummy
           \ || (a:is_skip_not_matched && !candidate.is_matched))
       let cnt += 1
@@ -679,12 +680,13 @@ function! unite#mappings#cursor_down(is_skip_not_matched) "{{{
 
   let num = line('.') - 1
   let cnt = 1
+  let offset = prompt_linenr == 1 ? 1 : 0
   if line('.') == prompt_linenr
     let cnt += 1
   endif
 
   while 1
-    let candidate = get(unite#get_unite_candidates(), num + cnt, {})
+    let candidate = get(unite#get_unite_candidates(), num - offset + cnt, {})
     if !empty(candidate) && (candidate.is_dummy
           \ || (a:is_skip_not_matched && !candidate.is_matched))
       let cnt += 1


### PR DESCRIPTION
- OS - Windows7 32bit
- Vim - ver.7.4.274 kaoriya

multi-line 表示で prompt が上に表示された時、カーソルを j,k で上下移動させると
カーソルがズレてしまい、action ができなくなります。
(prompt 表示なし、-prompt-direction=below 、candidate が一行表示の時は問題なし。
gj,gk でカーソルを合わせる事は可能)

```
:Unite jump -multi-line -prompt-visible
```

で再現するはず。

上に prompt が表示された分のカーソル位置を補正するパッチを書きましたが、いかがでしょうか？
