### PR TITLE
How about adding `g:unite_prompt_direction`

### DIFF
--- a/autoload/unite/variables.vim
+++ b/autoload/unite/variables.vim
@@ -226,7 +226,7 @@ function! unite#variables#default_context() "{{{
           \ 'sync' : 0,
           \ 'unique' : 0,
           \ 'execute_command' : '',
-          \ 'prompt_direction' : '',
+          \ 'prompt_direction' : g:unite_prompt_direction,
           \ 'prompt_visible' : 0,
           \ 'unite__direct_switch' : 0,
           \ 'unite__is_interactive' : 1,

--- a/doc/unite.txt
+++ b/doc/unite.txt
@@ -407,6 +407,12 @@ g:unite_prompt			                *g:unite_prompt*
 
 		The default value is '> '.
 
+g:unite_prompt_direction			*g:unite_prompt_direction*
+		Unite default prompt direction. Can also be set with
+		`-prompt-direction` command line argument.
+
+		The default value is ''.
+
 g:unite_enable_start_insert			*g:unite_enable_start_insert*
 		If this variable is 1, unite buffer will be in Insert Mode
 		immediately.

--- a/plugin/unite.vim
+++ b/plugin/unite.vim
@@ -46,6 +46,8 @@ let g:unite_update_time =
       \ get(g:, 'unite_update_time', 500)
 let g:unite_prompt =
       \ get(g:, 'unite_prompt', '> ')
+let g:unite_prompt_direction =
+      \ get(g:, 'unite_prompt_direction', '')
 let g:unite_enable_start_insert =
       \ get(g:, 'unite_enable_start_insert', 0)
 let g:unite_split_rule =


### PR DESCRIPTION
First, thank you for a great plugin.

I'm using Unite with `g:unite_split_rule` as follows:

```
let g:unite_split_rule = 'botright'
```

This option seems to change a prompt direction after changing in d4679530a593cd8c4f686f0b5059d2fc166832a5.

I want to show the unite buffer at the bottom but don't want to reverse a direction.
We can use `-prompt-direction` option to change a direction, but I think it's inconvenience to apply setting to the whole.

So I added `g:unite_prompt_direction` to change a prompt direction of all sources.
Hou about it?
## 

素晴らしいプラグインをありがとうございます。
下記のように、Uniteを `g:unite_split_rule` オプションとともに利用しています。

```
let g:unite_split_rule = 'botright'
```

おそらく d4679530a593cd8c4f686f0b5059d2fc166832a5 の変更のあたりから、この設定がprompt directionにも影響するようになっているかと思います。

自分はUniteのバッファを下部に表示したまま、prompt directionは反転させずに利用したいと考えています。
`-prompt-direction` で個別の設定は変更できますが、全体に適用するには不便ではないかと思いました。

そこで、他の設定にならって `g:unite_prompt_direction` を追加してみました。
いかがでしょうか。
### Environment
- OS: OS X 10.9.3
- Vim version: 7.4, patch: 1-258  
