### PR TITLE
fix matchaddpos feature detection

### DIFF
--- a/autoload/unite/view.vim
+++ b/autoload/unite/view.vim
@@ -785,7 +785,7 @@ function! unite#view#_redraw_echo(expr) "{{{
 endfunction"}}}
 
 function! unite#view#_match_line(highlight, line, id) "{{{
-  return has('patch7.4.340') ?
+  return (v:version > 704 || (v:version == 704 && has("patch330"))) ?
         \ matchaddpos(a:highlight, [a:line], 10, a:id) :
         \ matchadd(a:highlight, '^\%'.a:line.'l.*', 10, a:id)
 endfunction"}}}


### PR DESCRIPTION
- Problems summary
  
  Errors on many unite calls, this was produced with `:Unite -buffer-name=files buffer file_mru bookmark file_rec/async`:

```
[file_rec/async] Directory traverse was completed.
Error detected while processing function <SNR>55_call_unite_empty..unite#start..unite#start#standard..unite#view#_init_cursor..unite#view#_set_cursor_line..unite#view#_match_line:
line    1:
E117: Unknown function: matchaddpos
E15: Invalid expression: has('patch7.4.340') ? matchaddpos(a:highlight, [a:line], 10, a:id) : matchadd(a:highlight, '^\%'.a:line.'l.*', 10, a:id)
```
- Expected
  
  No errors.
- Environment Information
  - OS: Mac OS X
  - Vim version: MacVim via Homebrew, 7.4.273
  1. startup vim
  2. run `:Unite -buffer-name=files buffer file_mru bookmark file_rec/async`
