### PR TITLE
Fix bug that happens when use -resume with -start-insert.

### DIFF
--- a/autoload/unite/view.vim
+++ b/autoload/unite/view.vim
@@ -528,16 +528,8 @@ function! unite#view#_init_cursor() "{{{
 
   if context.start_insert && !context.auto_quit
     let unite.is_insert = 1
-
-    if is_restore && unite.is_resume
-      " Restore position.
-      call setpos('.', positions[key].pos)
-      call cursor(0, 1)
-      startinsert
-    else
-      call unite#helper#cursor_prompt()
-      startinsert!
-    endif
+    call unite#helper#cursor_prompt()
+    startinsert!
   else
     let unite.is_insert = 0
 


### PR DESCRIPTION
- Problems summary

When reusing a unite buffer, with the `start-insert` option set, sometimes the cursor is placed before the prompt sign.
- Expected

With `start-insert` option set, when reusing a unite buffer, always place the cursor at the end of the prompt line.
- Environment Information
  - OS: OS X Mavericks.
  - Vim version:

``` console
$ vim --version
VIM - Vi IMproved 7.4 (2013 Aug 10, compiled Jul 16 2014 09:51:29)
MacOS X (unix) version
Included patches: 1-367
```
- Minimal vimrc less than 50 lines

``` VimL
" minimal.vimrc
if has('vim_starting')
  set nocompatible
  set runtimepath=~/.vim/bundle/unite.vim/
endif
```
- How to reproduce
  
  Here is a gif showing the bug:

![unite](https://cloud.githubusercontent.com/assets/120483/3615910/0ef17b32-0dcd-11e4-9bc6-065fc575079a.gif)
