### PR TITLE
Add g:unite_source_buffer_show_filetype variable

### DIFF
--- a/autoload/unite/sources/buffer.vim
+++ b/autoload/unite/sources/buffer.vim
@@ -30,6 +30,9 @@ set cpo&vim
 call unite#util#set_default(
       \ 'g:unite_source_buffer_time_format',
       \ '(%Y/%m/%d %H:%M:%S) ')
+call unite#util#set_default(
+      \ 'g:unite_source_buffer_show_filetype',
+      \ 1)
 "}}}
 
 function! unite#sources#buffer#define() "{{{
@@ -196,7 +199,7 @@ function! s:make_abbr(bufnr, flags) "{{{
             \ '\=printf("%*s %-*s", 3, submatch(1), 4, submatch(2))', 'g') . path
     endif
 
-    if filetype != ''
+    if g:unite_source_buffer_show_filetype && filetype != ''
       let path .= ' [' . filetype . ']'
     endif
   endif

--- a/doc/unite.txt
+++ b/doc/unite.txt
@@ -445,6 +445,12 @@ g:unite_source_buffer_time_format
 
 		The default value is "(%Y/%m/%d %H:%M:%S) ".
 
+					*g:unite_source_buffer_show_filetype*
+g:unite_source_buffer_show_filetype
+		If this variable is set to 0 filetype for candidates of
+		|unite-source-buffer| will be omitted.
+		The default value is 1.
+
 g:unite_source_file_ignore_pattern	*g:unite_source_file_ignore_pattern*
 		Note: This variable is deprecated.  Please use
 		|unite#custom#source()| instead.


### PR DESCRIPTION
Add variable for users to be able to omit filetype names in buffer source which I find very annoying as in 99% you can figure out filetype from file extension.
