### PR TITLE
List symlink location, not real file location, in unite buffer

### DIFF
--- a/autoload/unite/sources/rec.vim
+++ b/autoload/unite/sources/rec.vim
@@ -493,8 +493,8 @@ function! s:get_files(context, files, level, max_unit) "{{{
 
     if isdirectory(file)
       if getftype(file) ==# 'link'
-        let file = s:resolve(file)
-        if file == ''
+        let real_file = s:resolve(file)
+        if real_file == ''
           continue
         endif
       endif
@@ -523,8 +523,8 @@ function! s:get_files(context, files, level, max_unit) "{{{
 
         if isdirectory(child)
           if getftype(child) ==# 'link'
-            let child = s:resolve(child)
-            if child == ''
+            let real_file = s:resolve(child)
+            if real_file == ''
               continue
             endif
           endif


### PR DESCRIPTION
When performing (fuzzy) file searches from the current directory
downwards, I imagine most users would prefer to filter on the symlink's
path rather than the actual file location. E.g. if I symlink
/Users/me/Dropbox/code/project1 to /Users/me/src/python/django/project1,
and am currently in /Users/me/src/python, I'd want to be able to use
'django' in the fuzzy search string, and wouldn't care in the least
about the 'Dropbox' part.
