### PR TITLE
Make unite.redraw_hold_candidates configurable

### DIFF
--- a/autoload/unite/init.vim
+++ b/autoload/unite/init.vim
@@ -29,6 +29,9 @@ set cpo&vim
 " Global options definition. "{{{
 let g:unite_ignore_source_files =
       \ get(g:, 'unite_ignore_source_files', [])
+let g:unite_redraw_hold_candidates =
+      \ get(g:, 'unite_redraw_hold_candidates',
+      \     (unite#util#has_lua() ? 20000 : 10000))
 "}}}
 
 function! unite#init#_context(context, ...) "{{{
@@ -305,7 +308,7 @@ function! unite#init#_current_unite(sources, context) "{{{
   let unite.args = unite#helper#get_source_args(a:sources)
   let unite.msgs = []
   let unite.err_msgs = []
-  let unite.redraw_hold_candidates = (unite#util#has_lua() ? 20000 : 10000)
+  let unite.redraw_hold_candidates = g:unite_redraw_hold_candidates
   let unite.disabled_max_candidates = 0
   let unite.cursor_line_time = reltime()
   let unite.match_id = 11

--- a/doc/unite.txt
+++ b/doc/unite.txt
@@ -436,6 +436,13 @@ g:unite_no_default_keymappings		*g:unite_no_default_keymappings*
 
 		This variable doesn't exist unless you define it explicitly.
 
+g:unite_redraw_hold_candidates		*g:unite_redraw_hold_candidates*
+		If the number of unite candidates is not greater than this
+		variable, all the candidates are holded for redrawing.
+
+		If lua is enabled, the default value is 20000, otherwise
+		10000.
+
 SOURCES VARIABLES 				*unite-sources-variables*
 
 					*g:unite_source_buffer_time_format*


### PR DESCRIPTION
### Problem

I use unite.vim to choose a file to edit from all files in one repository.
But some projects I contribute to have 30000+ files.
In such a case, filtering does not happen and I can't select a file to edit.

I tried async sources too, but there are some files which can't be matched.
I want to search a file from all the files.
- Environment information
  - OS: Mac OSX 10.9.3
  - Vim: 7.4.253
### Solution

I realised that its limitation is the same as `unite.redraw_hold_candidates`.
So I want `unite.redraw_hold_candidates` to be configurable.
