### PR TITLE
下プロンプトで'*'による候補全選択ができない

### DIFF
--- a/autoload/unite/mappings.vim
+++ b/autoload/unite/mappings.vim
@@ -404,7 +404,12 @@ function! s:toggle_mark_candidates(start, end) "{{{
       if line('.') == unite.prompt_linenr
         call unite#helper#skip_prompt()
       else
-        call s:toggle_mark('j')
+        let context = unite#get_context()
+        if context.prompt_direction ==# 'below'
+          call s:toggle_mark('k')
+        else
+          call s:toggle_mark('j')
+        endif
       endif
     endfor
   finally


### PR DESCRIPTION
連続ですみません、ノーマルモードの`*`で全選択ができなかったのでLingrで質問させていただいたところ、[下プロンプトが原因](http://lingr.com/room/vim/archives/2014/08/10#message-19902344)だと判明しました。こちらで直してみたのですが、不慣れなもので壊さずに直せたか不安なのでチェックお願いします。

また、下にプロンプトを表示させた場合、`<Space>`で選択すると上に移動する動作は正しいのでしょうか？
