### PR TITLE
macher_fuzzy should match shortest substring

### DIFF
--- a/autoload/unite/filters/matcher_fuzzy.vim
+++ b/autoload/unite/filters/matcher_fuzzy.vim
@@ -38,10 +38,13 @@ let s:matcher = {
       \}
 
 function! s:matcher.pattern(input) "{{{
-  let [head, input] = unite#filters#matcher_fuzzy#get_fuzzy_input(
-        \ unite#util#escape_match(a:input))
-  return substitute(head . substitute(input,
-        \ '\([[:alnum:]_/-]\|\\\.\)\ze.', '\0.\\{-}', 'g'), '\*\*', '*', 'g')
+  let chars = map(split(a:input, '\zs'), "escape(v:val, '\\[]^$.*')")
+    let pattern =
+    \   '\v' .
+    \   join(map(chars[0:-2], "
+    \       printf('%s[^%s]{-}', v:val, v:val)
+    \   "), '') . chars[-1]
+    return pattern
 endfunction"}}}
 
 function! s:matcher.filter(candidates, context) "{{{


### PR DESCRIPTION
Take this example directory structure:

```
./config/plugin/fugitive.vim
./config/plugin/indentLine.vim
./config/plugin/unite.vim
```

Now try to search for `unite` using the `fuzzy_matcher`
Matches are like this:

![screen shot 2014-10-05 at 1 38 40 am](https://cloud.githubusercontent.com/assets/223760/4518002/0ab9655c-4c6b-11e4-8d8a-bf34d765955b.png)

The regex generated here is: `u.\{-}n.\{-}i.\{-}t.\{-}e`

When I actually would expect:

![screen shot 2014-10-05 at 1 39 32 am](https://cloud.githubusercontent.com/assets/223760/4518004/275020ac-4c6b-11e4-9e51-5f6ab6888e3e.png)

The one I used here is: `u\(.\{-}u.\{-}n.\{-}i.\{-}t.\{-}e\)\@!.\{-}n\(.\{-}u.\{-}n.\{-}i.\{-}t.\{-}e\)\@!.\{-}i\(.\{-}u.\{-}n.\{-}i.\{-}t.\{-}e\)\@!.\{-}t\(.\{-}u.\{-}n.\{-}i.\{-}t.\{-}e\)\@!.\{-}e`

That uses negative lookaheads, I'm not sure how that would perform and also as far as I know regexes in lua do not support negative lookaheads.

@Shougo do you know how hard would it be to implement this on the fuzzy matcher?
