### PR TITLE
Compare with equality, not regexp.

### DIFF
--- a/autoload/unite/filters/matcher_hide_current_file.vim
+++ b/autoload/unite/filters/matcher_hide_current_file.vim
@@ -43,7 +43,7 @@ function! s:matcher.filter(candidates, context) "{{{
   let file = unite#util#substitute_path_separator(
         \ fnamemodify(bufname(unite#get_current_unite().prev_bufnr), ':p'))
   return filter(a:candidates, "
-        \ get(v:val, 'action__path', v:val.word) !~# file")
+        \ get(v:val, 'action__path', v:val.word) !=# file")
 endfunction"}}}
 
 let &cpo = s:save_cpo


### PR DESCRIPTION
Problem: comparison uses regexp

Example:
1. edit file "fooApy"
2. edit file "foo.py"
3. show mru with current file hidden matcher
4. see that fooApy is not listed
