### PR TITLE
trash-cli + pyenv でファイルの削除ができない場合があることに対する一つの解法

### DIFF
--- a/autoload/unite/kinds/file.vim
+++ b/autoload/unite/kinds/file.vim
@@ -30,14 +30,14 @@ set cpo&vim
 call unite#util#set_default(
       \ 'g:unite_kind_file_delete_file_command',
       \ unite#util#is_windows() && !executable('rm') ? '' :
-      \ executable('trash-put') ? 'trash-put $srcs' :
       \ executable('rmtrash') ? 'rmtrash $srcs' :
+      \ executable('trash-put') ? 'trash-put $srcs' :
       \ 'rm $srcs')
 call unite#util#set_default(
       \ 'g:unite_kind_file_delete_directory_command',
       \ unite#util#is_windows() && !executable('rm') ? '' :
-      \ executable('trash-put') ? 'trash-put $srcs' :
       \ executable('rmtrash') ? 'rmtrash $srcs' :
+      \ executable('trash-put') ? 'trash-put $srcs' :
       \ 'rm -r $srcs')
 call unite#util#set_default(
       \ 'g:unite_kind_file_copy_file_command',


### PR DESCRIPTION
### 前提
- pyenv を利用し Python 2.x / 3.x の双方を利用している
- pyenv の Python 2.x に trash-cli がインストールされている
- MacVim である
### 問題

pyenvを利用しシェルのPythonを2.x系にし`trash-put`をインストール後、同様にして3.x系に切り替えた場合 `trash-put` コマンドを実行すると pyenv から`pyenv: trash-put is not found`と怒られる。ただし`which trash-put`は`~/.pyenv/shims/trash-put`を返すためVimの`executable`は1を返してしまい実際には`trash-put`が使えない環境において`trash-put`が優先的に使用されてしまう。

もちろん、この問題はUnite.vimの問題ではなく`which trash-put`を実行可能にするpyenvやPython 3に対応していないtrash-cli側の問題ですが、MacVimならば`rmtrash`との評価順番を入れ替えるだけで簡単に解決可能なので考えてみていただけないかな？と思いPRしました。
