### PR TITLE
sort buffer name by postfix number

### DIFF
--- a/autoload/unite/helper.vim
+++ b/autoload/unite/helper.vim
@@ -213,13 +213,17 @@ function! unite#helper#get_postfix(prefix, is_create, ...) "{{{
   let prefix = substitute(a:prefix, '@\d\+$', '', '')
   let buffers = get(a:000, 0, range(1, bufnr('$')))
   let buflist = sort(filter(map(buffers,
-        \ 'bufname(v:val)'), 'stridx(v:val, prefix) >= 0'))
+        \ 'bufname(v:val)'), 'stridx(v:val, prefix) >= 0'), 's:sort_buffer_name')
   if empty(buflist)
     return ''
   endif
 
   return a:is_create ? '@'.(matchstr(buflist[-1], '@\zs\d\+$') + 1)
         \ : matchstr(buflist[-1], '@\d\+$')
+endfunction"}}}
+
+function! s:sort_buffer_name(lhs, rhs) "{{{
+  return matchstr(a:lhs, '@\zs\d\+$') - matchstr(a:rhs, '@\zs\d\+$')
 endfunction"}}}
 
 function! unite#helper#convert_source_name(source_name) "{{{


### PR DESCRIPTION
* Problems summary
`:Unite -create` names buffer `[unite] - default@10` next to  `[unite] - default@10`.

* Expected
`:Unite -create` names buffer `[unite] - default@11`, `[unite] - default@12`, `[unite] - default@13`...

* Environment Information
 * OS: Linux 64bit
 * Vim version: 7.4.580

* Minimal vimrc less than 50 lines

```VimL
" minimal.vimrc
if has('vim_starting')
  set nocompatible
  set runtimepath+=~/unite.vim/
endif
set showtabline=2
```

* How to reproduce

 0. startup vim: `vim -u minimal.vimrc`
 1. `:Unite -create file` 12 times.