### PR TITLE
Fix #703: ignore -no-split if bufhidden={unload,delete,wipe}

### DIFF
--- a/autoload/unite/init.vim
+++ b/autoload/unite/init.vim
@@ -88,7 +88,8 @@ function! unite#init#_context(context, ...) "{{{
     let context.horizontal = 1
     let context.direction = 'belowright'
   endif
-  if &l:modified && !&l:hidden
+  if (!&l:hidden && &l:modified)
+        \ || (&l:hidden && &l:bufhidden =~# 'unload\|delete\|wipe')
     " Split automatically.
     let context.split = 1
   endif

--- a/doc/unite.txt
+++ b/doc/unite.txt
@@ -1659,7 +1659,9 @@ the context dictionary.
 
 						*unite-options-no-split*
 		-no-split
-		Open the unite buffer in the current window.
+		Open the unite buffer in the current window instead of a new
+		window. This is ignored if the current buffer has set
+		'bufhidden' to unload/delete/wipe.
 		Default: split
 
 						*unite-options-no-cursor-line*


### PR DESCRIPTION
Some buffers (e.g. the fugitive.vim commit window) set `bufhidden=wipe` to avoid clogging up the :ls list and jumplist. If `:Unite -no-split` hides such a buffer, this is very frustrating, and it in the worst case, it causes data loss.