### PR TITLE
Fixed tabswitch when the current tab is the target

### DIFF
--- a/autoload/unite/kinds/openable.vim
+++ b/autoload/unite/kinds/openable.vim
@@ -222,7 +222,7 @@ let s:kind.action_table.tabswitch = {
       \ 'is_selectable' : 1,
       \ }
 function! s:kind.action_table.tabswitch.func(candidates) "{{{
-  for candidate in s:filter_bufpath(a:candidates)
+  for candidate in a:candidates
     if s:switch(candidate)
       call unite#take_action('tabopen', candidate)
     endif


### PR DESCRIPTION
The tabswitch action filtered out the file in the current buffer, this prevented
it from "switching" to the right location in the current tab when it's the one
that has the candidate open.