### PR TITLE
Sort unite.prev_bufnr last in buffer list

### DIFF
--- a/autoload/unite/sources/buffer.vim
+++ b/autoload/unite/sources/buffer.vim
@@ -210,7 +210,9 @@ function! s:make_abbr(bufnr, flags) "{{{
          \ unite#util#substitute_path_separator(path) . ' '
 endfunction"}}}
 function! s:compare(candidate_a, candidate_b) "{{{
-  return a:candidate_b.source__time - a:candidate_a.source__time
+  return a:candidate_a.action__buffer_nr == unite#get_current_unite().prev_bufnr ?  1 :
+      \ (a:candidate_b.action__buffer_nr == unite#get_current_unite().prev_bufnr ? -1 :
+      \ a:candidate_b.source__time - a:candidate_a.source__time)
 endfunction"}}}
 function! s:get_buffer_list(is_bang, is_question, is_plus, is_minus) "{{{
   " Get :ls flags.


### PR DESCRIPTION
The current buffer used to show up last in the buffer list until https://github.com/Shougo/unite.vim/commit/68ca112c64e0ea400b366151bc658fe8cc9269f6 which solved https://github.com/Shougo/unite.vim/issues/849. This change keeps https://github.com/Shougo/unite.vim/issues/849 solved but also keeps the old behavior of leaving the buffer Unite was called from at the bottom of the buffer list.