### PR TITLE
Fix filter patterns matching

### DIFF
--- a/autoload/unite/filters.vim
+++ b/autoload/unite/filters.vim
@@ -193,7 +193,7 @@ do
   local whites = vim.eval('a:whites')
   local candidates = vim.eval('a:candidates')
   for i = #candidates-1, 0, -1 do
-    local word = string.lower(candidates[i].action__path
+    local word = './' .. string.lower(candidates[i].action__path
         or candidates[i].word)
     for j = #patterns-1, 0, -1 do
       if string.find(word, patterns[j]) then
@@ -221,8 +221,8 @@ function! unite#filters#vim_filter_patterns(candidates, patterns, whites) "{{{
   let pattern = join(a:patterns, '\|')
   let white = join(a:whites, '\|')
   return filter(a:candidates,
-        \ "get(v:val, 'action__path', v:val.word) !~? pattern
-        \  || (white != '' && get(v:val, 'action__path', v:val.word) =~? white)")
+        \ "'./'.get(v:val, 'action__path', v:val.word) !~? pattern"
+        \ .(empty(white) ? "" : "|| './'.get(v:val, 'action__path', v:val.word) =~? white"))
 endfunction"}}}
 
 function! unite#filters#globs2patterns(globs) "{{{

--- a/autoload/unite/filters.vim
+++ b/autoload/unite/filters.vim
@@ -222,7 +222,7 @@ function! unite#filters#vim_filter_patterns(candidates, patterns, whites) "{{{
   let white = join(a:whites, '\|')
   return filter(a:candidates,
         \ "'./'.get(v:val, 'action__path', v:val.word) !~? pattern"
-        \ .(empty(white) ? "" : "|| './'.get(v:val, 'action__path', v:val.word) =~? white"))
+        \ .(white == "" ? "" : "|| './'.get(v:val, 'action__path', v:val.word) =~? white"))
 endfunction"}}}
 
 function! unite#filters#globs2patterns(globs) "{{{


### PR DESCRIPTION
`:Unite file` など、結果が相対パスで出力される場合に ignore_globs とマッチしない。
glob の展開で先頭に / が挿入されるためだが、lua でのパターン生成が難しいため filter_patterns 側を修正。
