### PR TITLE
Provide support for Unite to run in WIndows from a SMB file share.

### DIFF
--- a/autoload/vital/_unite.vim
+++ b/autoload/vital/_unite.vim
@@ -161,12 +161,13 @@ if filereadable(expand('<sfile>:r') . '.VIM')
     " Note: On windows, vim can't expand path names from 8.3 formats.
     " So if getting full path via <sfile> and $HOME was set as 8.3 format,
     " vital load duplicated scripts. Below's :~ avoid this issue.
+
     return tolower(fnamemodify(resolve(fnamemodify(
-    \              a:path, ':p')), ':~:gs?[\\/]\+?/?'))
+    \              a:path, ':p')), ':~:gs?[\\/]?/?'))
   endfunction
 else
   function! s:_unify_path(path)
-    return resolve(fnamemodify(a:path, ':p:gs?[\\/]\+?/?'))
+    return resolve(fnamemodify(a:path, ':p:gs?[\\/]?/?'))
   endfunction
 endif
 


### PR DESCRIPTION
When running on Windows, and using unite.vim from a SMB share (with runtimepath starting with "\\server" or "//server"), s:_unify_path was replacing double slashes or double back slashes by a single slash. Hence, vital was not being able to locate files.

With this changes, the double slashes will remain as double.