### PR TITLE
Fix rec_file/neovim recursive bug

### DIFF
--- a/autoload/unite/sources/rec.vim
+++ b/autoload/unite/sources/rec.vim
@@ -407,12 +407,6 @@ function! s:job_handler(job_id, data, event) abort "{{{
   endif
 
   let candidates += lines
-
-  if a:event ==# 'stdout'
-    let job.candidates += candidates
-  elseif a:event ==# 'stderr'
-    let job.errors += candidates
-  endif
 endfunction"}}}
 
 function! s:source_file_neovim.gather_candidates(args, context) "{{{


### PR DESCRIPTION
The candidate list is already selected correctly in line 394:

```vim
let candidates = (a:event ==# 'stdout') ? job.candidates : job.errors
```

After the candidates are added the block:
```vim
if a:event ==# 'stdout'		
  let job.candidates += candidates		
elseif a:event ==# 'stderr'		
  let job.errors += candidates		
endif
```

is adding them all over again. This caused excessive slowdown and memory usage when using file_rec/neovim