### PR TITLE
Line numbers for history yank source, and find source may also use context.input

### DIFF
--- a/autoload/unite/sources/find.vim
+++ b/autoload/unite/sources/find.vim
@@ -56,7 +56,7 @@ function! s:source.hooks.on_init(args, context) "{{{
   endif
 
   let a:context.source__targets = split(target, "\n")
-  let a:context.source__input = get(a:args, 1, '')
+  let a:context.source__input = get(a:args, 1, a:context.input)
   if a:context.source__input == ''
     redraw
     echo "Please input command-line(quote is needed) Ex: -name '*.vim'"

--- a/autoload/unite/sources/history_yank.vim
+++ b/autoload/unite/sources/history_yank.vim
@@ -76,6 +76,7 @@ function! s:source.gather_candidates(args, context) "{{{
 
   return map(copy(s:yank_histories), "{
         \ 'word' : v:val[0],
+        \ 'abbr' : printf('%-2d - %s', v:key, v:val[0]),
         \ 'is_multiline' : 1,
         \ 'action__regtype' : v:val[1],
         \ }")


### PR DESCRIPTION
Hi, I've also add a line number for the history/yank source so it's easier to use. And also added the ability for the `find` source to use the `-input` option to be consistent with other sources.