### PR TITLE
Relative file names for grep source

### DIFF
--- a/autoload/unite/helper.vim
+++ b/autoload/unite/helper.vim
@@ -547,8 +547,9 @@ function! unite#helper#is_prompt(line) "{{{
 endfunction"}}}
 
 function! unite#helper#relative_target(target) "{{{
-  let target = fnamemodify(a:target, ':.')
-  if target == getcwd()
+  let target = unite#util#substitute_path_separator(substitute(fnamemodify(
+        \ a:target, ':.'), '[^:]zs/$', '', ''))
+  if target == unite#util#substitute_path_separator(getcwd())
     return '.'
   endif
   return target
@@ -556,8 +557,7 @@ endfunction"}}}
 
 function! unite#helper#join_targets(targets) "{{{
   return join(map(copy(a:targets),
-        \    "unite#util#escape_shell(substitute(
-        \               unite#helper#relative_target(v:val), '/$', '', ''))"))
+        \    "unite#util#escape_shell(unite#helper#relative_target(v:val))"))
 endfunction"}}}
 
 let &cpo = s:save_cpo

--- a/autoload/unite/helper.vim
+++ b/autoload/unite/helper.vim
@@ -546,10 +546,18 @@ function! unite#helper#is_prompt(line) "{{{
         \ || (context.prompt_direction !=# 'below' && a:line <= prompt_linenr)
 endfunction"}}}
 
+function! unite#helper#relative_target(target) "{{{
+  let target = fnamemodify(a:target, ':.')
+  if target == getcwd()
+    return '.'
+  endif
+  return target
+endfunction"}}}
+
 function! unite#helper#join_targets(targets) "{{{
   return join(map(copy(a:targets),
-        \    "unite#util#escape_shell(
-        \               substitute(v:val, '/$', '', ''))"))
+        \    "unite#util#escape_shell(substitute(
+        \               unite#helper#relative_target(v:val), '/$', '', ''))"))
 endfunction"}}}
 
 let &cpo = s:save_cpo


### PR DESCRIPTION
Current implementation passes full directory path as target to grep command. So, for example, ag command returns full file paths too.