### PR TITLE
Add silent option to vimgrep command

### DIFF
--- a/autoload/unite/sources/vimgrep.vim
+++ b/autoload/unite/sources/vimgrep.vim
@@ -109,7 +109,7 @@ function! s:source.gather_candidates(args, context) "{{{
     return []
   endif
 
-  let cmdline = printf('vimgrep /%s/j %s',
+  let cmdline = printf('silent vimgrep /%s/j %s',
     \   escape(a:context.source__input, '/'),
     \   join(a:context.source__targets))
 


### PR DESCRIPTION
Silencing command prevents vimgrep from outputting files as it
performs the search. Without this option, the vimgrep source
results in a "Press enter" prompt before displaying candidates,
requiring an extra keypress. Compare this behavior to the grep
source, which proceeds without interruption.