### PR TITLE
Fix issue #945

### DIFF
--- a/autoload/unite/helper.vim
+++ b/autoload/unite/helper.vim
@@ -548,7 +548,7 @@ endfunction"}}}
 
 function! unite#helper#relative_target(target) "{{{
   let target = unite#util#substitute_path_separator(substitute(fnamemodify(
-        \ a:target, ':.'), '[^:]zs/$', '', ''))
+        \ substitute(a:target, '/$', '', ''), ':.'), '[^:]zs/$', '', ''))
   if target == unite#util#substitute_path_separator(getcwd())
     return '.'
   endif

--- a/autoload/unite/helper.vim
+++ b/autoload/unite/helper.vim
@@ -547,8 +547,8 @@ function! unite#helper#is_prompt(line) "{{{
 endfunction"}}}
 
 function! unite#helper#relative_target(target) "{{{
-  let target = unite#util#substitute_path_separator(substitute(fnamemodify(
-        \ substitute(a:target, '/$', '', ''), ':.'), '[^:]zs/$', '', ''))
+  let target = unite#util#substitute_path_separator(fnamemodify(
+        \ substitute(a:target, '[^:]\zs/$', '', ''), ':.'))
   if target == unite#util#substitute_path_separator(getcwd())
     return '.'
   endif


### PR DESCRIPTION
fnamemodify関数の実行後にtargetが""になってしまうのが原因で、`Unite grep`のTargetが""になってしまう。
#942 以前のunite#helper#join_targetsで使用されていたファイルパス解決処理を間に挟むと、問題が解消される