### PR TITLE
fix relative_target() for windows

### DIFF
--- a/autoload/unite/helper.vim
+++ b/autoload/unite/helper.vim
@@ -552,6 +552,11 @@ function! unite#helper#relative_target(target) "{{{
   if target == unite#util#substitute_path_separator(getcwd())
     return '.'
   endif
+  if unite#util#is_windows()
+    let drive_letter = matchstr(a:target, '^\a:')
+    let target = strpart(target, 0, 1) ==# '/' && drive_letter !=# '' ?
+          \ drive_letter . target : target
+  endif
   return target
 endfunction"}}}
 


### PR DESCRIPTION
windows だと #942 の影響で絶対パスを grep source の target に指定するとドライブレターが無くなり検索できないことがあります。
fnamemodify(fname, ':.') によってドライブレターが無くなるのが原因なので、windows で絶対パスの場合はドライブレターを追加するようにしました。

help の記述に合ってないので fnamemodify() の問題かもしれませんが、ひとまずはこのようにした方が良いかと考えます。