### PR TITLE
action vimgrep がエラーで動作しない

### DIFF
--- a/autoload/unite/kinds/file_base.vim
+++ b/autoload/unite/kinds/file_base.vim
@@ -288,8 +288,8 @@ let s:kind.action_table.vimgrep = {
   \ }
 function! s:kind.action_table.vimgrep.func(candidates) "{{{
   call unite#start_script([
-        \ ['vimgrep', map(copy(a:candidates),
-        \ 'string(substitute(v:val.action__path, "/$", "", "g"))'),
+        \ ['vimgrep', join(map(copy(a:candidates),
+        \ 'substitute(v:val.action__path, "/$", "", "g")'), "\n"),
         \ ]], { 'no_quit' : 1 })
 endfunction "}}}
 


### PR DESCRIPTION
今の vimgrep action は vimgrep source に string(action__path) のリストが渡されていますが
unite#helper#parse_source_args() は文字列しか受けないのでエラーになります。

改行で action__path を区切った文字列を渡すようにしました。

