### PR TITLE
vimgrep source に空白を含むパス名を指定すると検索できない

### DIFF
--- a/autoload/unite/sources/vimgrep.vim
+++ b/autoload/unite/sources/vimgrep.vim
@@ -111,7 +111,7 @@ function! s:source.gather_candidates(args, context) "{{{
 
   let cmdline = printf('silent vimgrep /%s/j %s',
     \   escape(a:context.source__input, '/'),
-    \   join(a:context.source__targets))
+    \   join(map(copy(a:context.source__targets), 'escape(v:val, " ")')))
 
   call unite#print_source_message(
         \ 'Command-line: ' . cmdline, s:source.name)


### PR DESCRIPTION
target に "Program files" のような空白を含む path を指定すると検索できなくなります。
glob の場合は vimgrep コマンドが展開するようですが、直接指定や vimgrep action で path を渡す場合は
エスケープする必要があるので、エスケープ処理を入れました。