### PR TITLE
action vimgrep で複数の絶対パスを指定すると最初の一つしか検索できない

### DIFF
--- a/autoload/unite/helper.vim
+++ b/autoload/unite/helper.vim
@@ -224,12 +224,16 @@ function! unite#helper#parse_source_path(path) "{{{
   " Don't assume empty path means current directory.
   " Let the sources customize default rules.
   if path != ''
-    let path = unite#util#substitute_path_separator(
-          \ fnamemodify(unite#util#expand(path), ':p'))
+    let pathlist = path =~ "\n" ? split(path, "\n") : [path]
+    for pathitem in pathlist 
+      " resolve .. in the paths
+      let pathitem = resolve(unite#util#substitute_path_separator(
+            \ fnamemodify(unite#util#expand(pathitem), ':p')))
+    endfor
+    let path = join(pathlist, "\n")
   endif
 
-  " resolve .. in the paths
-  return resolve(path)
+  return path
 endfunction"}}}
 
 function! unite#helper#get_marked_candidates() "{{{

--- a/autoload/unite/helper.vim
+++ b/autoload/unite/helper.vim
@@ -225,7 +225,7 @@ function! unite#helper#parse_source_path(path) "{{{
   " Let the sources customize default rules.
   if path != ''
     let pathlist = path =~ "\n" ? split(path, "\n") : [path]
-    for pathitem in pathlist 
+    for pathitem in pathlist
       " resolve .. in the paths
       let pathitem = resolve(unite#util#substitute_path_separator(
             \ fnamemodify(unite#util#expand(pathitem), ':p')))


### PR DESCRIPTION
windows のみかもしれません。

原因は unite#helper#parse_source_path() の最後の resolve(path) で

  d:/foo/bar/somefile1.txt
  d:/foo/bar/somefile2.txt
  d:/foo/bar/somefile3.txt
  ...

と改行区切りされた文字列が resolve() を通すと

  d:/foo/bar/somefile1.txt
  d:foo/bar/somefile2.txt
  d:foo/bar/somefile3.txt
  ...

2行目以降でドライブレター直後のパス区切り('/')が消えてしまうためです。

unite#helper#parse_source_path() 自体が改行区切りの複数パスを渡される、
もしくは action から複数の candidates を渡されることを想定していないようだったので、
パッチのようにしてみました。

むしろ action から渡される引数であれば
unite#helper#parse_source_args() -> unite#helper#parse_source_path()
を通さずに action か source 自体で処理するべきなのかもしれませんが
Unite [source] コマンドからの引数なのか action からの引数なのかの判別処理
などが必要なようで、少し大きな変更になりそうなのでとりあえずはこれで。

追記: trailing space があったので直したパッチ追加しました。