### PR TITLE
Fix #961: neovim support for ag

### DIFF
--- a/autoload/unite/sources/rec.vim
+++ b/autoload/unite/sources/rec.vim
@@ -475,8 +475,8 @@ function! s:source_file_neovim.gather_candidates(args, context) "{{{
           \ (a:context.source__is_directory ? 'd' : 'f'), '-print']
   endif
 
-  " Use &shell and &cmdflags
-  let commands = [&shell, &cmdflags] + commands
+  " Use &shell and &shellcmdflag
+  let commands = [&shell, &shellcmdflag, join(commands, ' ')]
 
   " Note: "pt" needs pty.
   let a:context.source__job = jobstart(commands, {

--- a/doc/unite.txt
+++ b/doc/unite.txt
@@ -2145,8 +2145,6 @@ file_rec/async	Similar to |unite-source-file_rec|, but get files asynchronously.
 file_rec/neovim	Similar to |unite-source-file_rec|, but get files
 		asynchronously by neovim job APIs.
 		Note: Requires neovim and the "find" command.
-		Note: Does not work "ag" command.
-		https://github.com/Shougo/unite.vim/issues/961
 		Note: Windows "find" command is not supported.
 		Note: If you edit one of the files in Vim, the source will
 		update its cache.


### PR DESCRIPTION
- Fixes #961 properly
- Use &shellcmdflag instead of &cmdflags
- Pass a single string to the &shellcmdflag option