### PR TITLE
fix execution of mappings containing `<Space>` key

### DIFF
--- a/autoload/unite/sources/mapping.vim
+++ b/autoload/unite/sources/mapping.vim
@@ -78,7 +78,7 @@ function! s:source.hooks.on_init(args, context) "{{{
 
     call add(s:cached_result, {
           \ 'word' : line,
-          \ 'action__command' : 'execute "normal ' . map . '"',
+          \ 'action__command' : 'call feedkeys("' . map . '")',
           \ 'action__mapping' : map,
           \ })
   endfor


### PR DESCRIPTION
This patch fixes the `mapping` source's execution of mappings that
contain the `<Space>` key by using feedkeys() instead of `:normal`.