### PR TITLE
Add support for CtrlSpace to buffer_tab

### DIFF
--- a/autoload/unite/sources/buffer.vim
+++ b/autoload/unite/sources/buffer.vim
@@ -128,18 +128,22 @@ function! s:source_buffer_tab.gather_candidates(args, context) "{{{
           \                   a:context.source__is_minus)
   endif
 
-  if !exists('g:loaded_tabpagebuffer')
+  if !exists('g:loaded_tabpagebuffer') && !exists('g:CtrlSpaceLoaded')
     call unite#print_source_message(
-          \ 'tabpagebuffer plugin is not installed.', self.name)
+          \ 'tabpagebuffer or ctrlspace plugin is not installed.', self.name)
     return []
   endif
 
-  if !exists('t:tabpagebuffer')
+  if exists('t:tabpagebuffer')
+    let bufferlist = t:tabpagebuffer
+  elseif exists('t:CtrlSpaceList')
+    let bufferlist = t:CtrlSpaceList
+  else
     return []
   endif
 
   let list = filter(copy(a:context.source__buffer_list),
-        \ 'has_key(t:tabpagebuffer, v:val.action__buffer_nr)')
+        \ 'has_key(bufferlist, v:val.action__buffer_nr)')
 
   let candidates = map(list, "{
         \ 'word' : unite#util#substitute_path_separator(

--- a/doc/unite.txt
+++ b/doc/unite.txt
@@ -2188,8 +2188,12 @@ buffer_tab	Nominates opened buffers only in the current tab as
 		candidates, ordering by time series.
 		Arguments are the same as for |unite-source-buffer|.
 
-		Note: This source requires |tabpagebuffer|.  Please install.
+		Note: This source requires |tabpagebuffer| or |ctrlspace|.
+
+		Please install:
 		http://github.com/Shougo/tabpagebuffer.vim
+		or
+		http://github.com/szw/vim-ctrlspace
 
 		Source arguments:
 		1. "!", "?", "+" or "-".


### PR DESCRIPTION
I've added support for the tabs buffer list of CtrlSpace to Unite's tab_buffer source. Can you please add this?