### PR TITLE
fix unite#util#print_error

### DIFF
--- a/autoload/unite/util.vim
+++ b/autoload/unite/util.vim
@@ -103,7 +103,7 @@ function! unite#util#is_mac(...)
 endfunction
 function! unite#util#print_error(msg)
   let msg = '[unite.vim] ' . a:msg
-  return call(s:get_message().error, msg)
+  return call(s:get_message().error, [msg])
 endfunction
 function! unite#util#smart_execute_command(action, word)
   execute a:action . ' ' . fnameescape(a:word)


### PR DESCRIPTION
`:Unite x` throws the following error.
```
Error detected while processing function <SNR>61_call_unite..unite#start..unite#start#standard..unite#init#_current_unite..unite#init#_loaded_sources..unite#util#print_error:
line    2:
E714: List required
```

This pull request fixes the issue. The second argument of the `call` function should be a list.