### PR TITLE
Use more robust syntax highlight in unite grep

### DIFF
--- a/autoload/unite/sources/grep.vim
+++ b/autoload/unite/sources/grep.vim
@@ -115,11 +115,13 @@ function! s:source.hooks.on_syntax(args, context) "{{{
   endif
 
   syntax case ignore
-  syntax match uniteSource__GrepFile /[^:]*: / contained
+  syntax match uniteSource__GrepHeader /[^:]*: \d\+: \(\d\+: \)\?/ contained
         \ containedin=uniteSource__Grep
+  syntax match uniteSource__GrepFile /[^:]*: / contained
+        \ containedin=uniteSource__GrepHeader
         \ nextgroup=uniteSource__GrepLineNR
   syntax match uniteSource__GrepLineNR /\d\+: / contained
-        \ containedin=uniteSource__Grep
+        \ containedin=uniteSource__GrepHeader
         \ nextgroup=uniteSource__GrepPattern
   execute 'syntax match uniteSource__GrepPattern /'
         \ . substitute(a:context.source__input, '\([/\\]\)', '\\\1', 'g')


### PR DESCRIPTION
* Problems summary
When I grep some keywords from JSONs, `uniteSource__GrepFile` syntax is matched to key of JSON. Also `uniteSource__GrepSeparator` match `:` in JSON and conceal it.
This problem will occur on some files that contained `:` (typically format is JSON and YAML)

* Expected
`uniteSource__GrepFile` match only filename.

* Environment Information
 * OS: CentOS 6.6
 * Vim version: 7.4.729
 * Grep engine: `vimgrep`, `ag`

* Minimal vimrc less than 50 lines

```VimL
set nocompatible

set runtimepath+=~/.vim/bundle/unite.vim/
set runtimepath+=~/.vim/bundle/vimproc.vim/

syntax on
```

* How to reproduce

prerequisites: 
Save following JSON as `./sample.json`.
```JSON
{
  "key1": "value",
  "key2": "value, key",
  "key3": "value: dummy"
}
```

 0. startup vim
 1. `:Unite grep:. -no-split -buffer-name=search-buffer`
 2. Input `key` as search pattern

* Screen shot (if possible)

Original:
![original](https://cloud.githubusercontent.com/assets/191358/10360950/d8917924-6ddf-11e5-838d-78576f4eab77.png)

Fixed:
![fixed](https://cloud.githubusercontent.com/assets/191358/10360955/e1475e30-6ddf-11e5-89bc-08a932795b49.png)

* Remarks

If possible, I want to use `^` regex in `uniteSource__GrepFile`. but it doesn't work as I expect.
This `uniteSource__GrepHeader` pattern is not perfect, but more robust than current pattern.
