### PR TITLE
Fix insert_enter nomodifiable problem

### DIFF
--- a/autoload/unite/mappings.vim
+++ b/autoload/unite/mappings.vim
@@ -542,7 +542,7 @@ function! s:insert_enter(key) "{{{
 
   return (line('.') != unite.prompt_linenr) ?
         \ (unite.context.prompt_focus ?
-        \     unite.prompt_linenr.'GA' : '0i') :
+        \     unite.prompt_linenr.'GA' : 'gI') :
         \ (a:key == 'i' && col('.') <= 1
         \     || a:key == 'a' && col('.') < 1) ?
         \     'A' :


### PR DESCRIPTION
When the cursor is not on the prompt line and is also not in the first column, `<Plug>(unite_insert_enter)` fails with `E21: Cannot make changes, 'modifiable' is off`. The problem happens because `0i` triggers the `CursorMoved` autocommand which sets `modifiable` again before insert mode is entered. Using `gI` instead of `0i` still inserts at the first column (even if there is leading whitespace, unlike `I`) but avoids the autocommand.