### PR TITLE
Fix toggle mark for multiline candidates

### DIFF
--- a/autoload/unite/mappings.vim
+++ b/autoload/unite/mappings.vim
@@ -482,7 +482,12 @@ function! s:toggle_mark_candidates(start, end) "{{{
   let pos = getpos('.')
   try
     call cursor(a:start, 1)
+    let prev = -1
     for _ in range(a:start, a:end)
+      if line('.') == prev || line('.') < a:start || line('.') > a:end
+        break
+      endif
+      let prev = line('.')
       if line('.') == unite.prompt_linenr
         call unite#helper#skip_prompt()
       else


### PR DESCRIPTION
The `s:toggle_mark_candidates` function assumes that it needs to toggle marks for the same number of candidates as the range of lines. However, when there are multiline candidates, toggling mark makes the cursor move multiple lines so it gets to the last line in the range and toggles its mark multiple times. This fix stops toggling marks after the cursor moves outside of the `a:start : a:end` range and works with either prompt direction, with toggling all candidates, and toggling visually selected candidates.