### PR TITLE
Restore prev_winsaveview after temporary Unite

### DIFF
--- a/autoload/unite/start.vim
+++ b/autoload/unite/start.vim
@@ -203,6 +203,7 @@ function! unite#start#temporary(sources, ...) "{{{
   endif
   let unite.winnr = unite_save.winnr
   let unite.has_preview_window = unite_save.has_preview_window
+  let unite.prev_winsaveview = unite_save.prev_winsaveview
 
   " Restore current directory.
   execute 'lcd' fnameescape(cwd)


### PR DESCRIPTION
This fixes restoring cursor position after opening a temporary Unite.

For example, run `:Unite register -no-split`, press `<Plug>(unite_choose_action)` and choose an action that quits Unite. It will use `prev_winsaveview` from the register Unite buffer instead of from the starting buffer because the temporary Unite wipes out the one from the original buffer. Then the cursor will be moved to where it was in the `Unite register` buffer instead of where it was in the starting buffer.