### PR TITLE
selecta sorter: Support Python 3 and fix error when !has('python')

### DIFF
--- a/autoload/unite/filters/sorter_selecta.py
+++ b/autoload/unite/filters/sorter_selecta.py
@@ -1,0 +1,91 @@
+"""===========================================================================
+" FILE: sorter_selecta.py
+" AUTHOR:  David Lee
+" CONTRIBUTOR:  Jean Cavallo
+" DESCRIPTION: Scoring code by Gary Bernhardt
+"     https://github.com/garybernhardt/selecta
+" License: MIT license
+"     Permission is hereby granted, free of charge, to any person obtaining
+"     a copy of this software and associated documentation files (the
+"     "Software"), to deal in the Software without restriction, including
+"     without limitation the rights to use, copy, modify, merge, publish,
+"     distribute, sublicense, and/or sell copies of the Software, and to
+"     permit persons to whom the Software is furnished to do so, subject to
+"     the following conditions:
+"
+"     The above copyright notice and this permission notice shall be included
+"     in all copies or substantial portions of the Software.
+"
+"     THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+"     OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+"     MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+"     IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+"     CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
+"     TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+"     SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+"
+"=========================================================================="""
+import vim
+import string
+BOUNDARY_CHARS = string.punctuation + string.whitespace
+
+
+def score():
+    score = get_score(vim.eval('candidate.word'), vim.eval('input'))
+    if score:
+        vim.command('let candidate.filter__rank += %s' % score)
+
+
+def get_score(string, query_chars):
+    # Highest possible score is the string length
+    best_score, best_range = len(string), None
+    head, tail = query_chars[0], query_chars[1:]
+
+    # For each occurence of the first character of the query in the string
+    for first_index in (idx for idx, val in enumerate(string)
+            if val == head):
+        # Get the score for the rest
+        score, last_index = find_end_of_match(string, tail, first_index)
+
+        if last_index and score < best_score:
+            best_score = score
+            best_range = (first_index, last_index)
+
+    # Solve equal scores by sorting on the string length. The ** 0.5 part makes
+    # it less and less important for big strings
+    best_score = best_score * (len(string) ** 0.5)
+    return best_score
+
+
+def find_end_of_match(to_match, chars, first_index):
+    score, last_index, last_type = 1.0, first_index, None
+
+    for char in chars:
+        try:
+            index = to_match.index(char, last_index + 1)
+        except ValueError:
+            return None, None
+        if not index:
+            return None, None
+
+        # Do not count sequential characters more than once
+        if index == last_index + 1:
+            if last_type != 'sequential':
+                last_type = 'sequential'
+                score += 1
+        # Same for first characters of words
+        elif to_match[index - 1] in BOUNDARY_CHARS:
+            if last_type != 'boundary':
+                last_type = 'boundary'
+                score += 1
+        # Same for camel case
+        elif char in string.ascii_uppercase and \
+                to_match[index - 1] in string.ascii_lowercase:
+            if last_type != 'camelcase':
+                last_type = 'camelcase'
+                score += 1
+        else:
+            last_type = 'normal'
+            score += index - last_index
+        last_index = index
+    return (score, last_index)

--- a/autoload/unite/filters/sorter_selecta.vim
+++ b/autoload/unite/filters/sorter_selecta.vim
@@ -37,6 +37,7 @@ function! unite#filters#sorter_selecta#define()
   endif
 endfunction
 
+let s:root = expand('<sfile>:p:h')
 let s:sorter = {
       \ 'name' : 'sorter_selecta',
       \ 'description' : 'sort by selecta algorithm',
@@ -81,13 +82,6 @@ endfunction
 " @vimlint(EVL102, 1, l:input)
 " @vimlint(EVL102, 1, l:candidate)
 function! s:sort_python(candidates, inputs)
-Python2or3 << PYTHONEOF
-import vim
-def score():
-    score = get_score(vim.eval('candidate.word'), vim.eval('input'))
-    if score:
-        vim.command('let candidate.filter__rank += %s' % score)
-PYTHONEOF
   for input in a:inputs
     for candidate in a:candidates
       Python2or3 score()
@@ -99,70 +93,17 @@ endfunction"}}}
 " @vimlint(EVL102, 0, l:input)
 " @vimlint(EVL102, 0, l:candidate)
 
+" @vimlint(EVL102, 1, l:root)
 function! s:def_python()
   if !(has('python') || has('python3'))
     return
   endif
-Python2or3 << PYTHONEOF
-import string
-
-BOUNDARY_CHARS = string.punctuation + string.whitespace
-
-def get_score(string, query_chars):
-    # Highest possible score is the string length
-    best_score, best_range = len(string), None
-    head, tail = query_chars[0], query_chars[1:]
-
-    # For each occurence of the first character of the query in the string
-    for first_index in (idx for idx, val in enumerate(string)
-            if val == head):
-        # Get the score for the rest
-        score, last_index = find_end_of_match(string, tail, first_index)
-
-        if last_index and score < best_score:
-            best_score = score
-            best_range = (first_index, last_index)
-
-    # Solve equal scores by sorting on the string length. The ** 0.5 part makes
-    # it less and less important for big strings
-    best_score = best_score * (len(string) ** 0.5)
-    return best_score
-
-
-def find_end_of_match(to_match, chars, first_index):
-    score, last_index, last_type = 1.0, first_index, None
-
-    for char in chars:
-        try:
-            index = to_match.index(char, last_index + 1)
-        except ValueError:
-            return None, None
-        if not index:
-            return None, None
-
-        # Do not count sequential characters more than once
-        if index == last_index + 1:
-            if last_type != 'sequential':
-                last_type = 'sequential'
-                score += 1
-        # Same for first characters of words
-        elif to_match[index - 1] in BOUNDARY_CHARS:
-            if last_type != 'boundary':
-                last_type = 'boundary'
-                score += 1
-        # Same for camel case
-        elif char in string.ascii_uppercase and \
-                to_match[index - 1] in string.ascii_lowercase:
-            if last_type != 'camelcase':
-                last_type = 'camelcase'
-                score += 1
-        else:
-            last_type = 'normal'
-            score += index - last_index
-        last_index = index
-    return (score, last_index)
-PYTHONEOF
+  let root = s:root
+  Python2or3 import sys
+  Python2or3 sys.path.insert(0, vim.eval('root'))
+  Python2or3 from sorter_selecta import score
 endfunction
+" @vimlint(EVL102, 0, l:root)
 
 call s:def_python()
 


### PR DESCRIPTION
These changes make the selecta sorter work with `has('python3')` (and `has('python')` as before). Also `s:def_python()` threw an error when called in Vim without Python support which can happen when `unite#get_filters()` is called, for example.