### PR TITLE
Fix sorter_selecta import error

### DIFF
--- a/autoload/unite/filters/sorter_selecta.vim
+++ b/autoload/unite/filters/sorter_selecta.vim
@@ -100,6 +100,7 @@ function! s:def_python()
   endif
   let root = s:root
   Python2or3 import sys
+  Python2or3 import vim
   Python2or3 sys.path.insert(0, vim.eval('root'))
   Python2or3 from sorter_selecta import score
 endfunction


### PR DESCRIPTION
@Shougo I tested with Python 2, Python 3, and no Python but I didn't test in neovim before submitting https://github.com/Shougo/unite.vim/pull/1068.  ~~Neovim gives this error if I don't `import vim` before importing from `sorter_selecta`.~~

```
Error detected while processing function <SNR>59_def_python..provider#python#Call:
line   18:
NameError("name 'vim' is not defined",)
```

~~Simply importing the `vim` module fixes it. @rosshadden Please check if this fixes the problem~~

Edit: Actually I just forgot to `import vim` before doing `vim.eval('root')`. It only worked for me because other plugins had imported the vim module. I used no other plugins when testing in neovim so that's why it only happened there.