### PR TITLE
Ignore auto-generated Python bytecode files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 doc/tags*
+*.pyc


### PR DESCRIPTION
Now that sorter_selecta is in a Python file, using it generates a .pyc file which should be ignored.