### PR TITLE
Ignore empty inputs in matcher_regexp

### DIFF
--- a/autoload/unite/filters/matcher_regexp.vim
+++ b/autoload/unite/filters/matcher_regexp.vim
@@ -47,6 +47,9 @@ function! s:matcher.filter(candidates, context) "{{{
 
   let candidates = a:candidates
   for input in a:context.input_list
+    if input == '!' || input == ''
+      continue
+    endif
     let a:context.input = input
     let candidates = unite#filters#matcher_regexp#regexp_matcher(
           \ candidates, input, a:context)


### PR DESCRIPTION
Adding a space after a word in the prompt shuffles around the candidates because the matcher gets an extra empty input. This check is already done in some of the other matchers so maybe it should go in `candidates.vim` instead.