### PR TITLE
Fix off-by-one error in line number function

### DIFF
--- a/autoload/unite/helper.vim
+++ b/autoload/unite/helper.vim
@@ -385,6 +385,8 @@ function! unite#helper#get_current_candidate_linenr(num) "{{{
     if unite.prompt_linenr == 0
       let num += line('$') + 1
     endif
+  else
+    let num += 1
   endif
 
   return unite.prompt_linenr + num


### PR DESCRIPTION
In https://github.com/Shougo/unite.vim/commit/a2a77fe47804df3d568e1d755f272ca9ca662955, `if candidate_num >= a:num+1` changed to `if candidate_num >= a:num`, and then the new logic only handles the `below` prompt direction case. The 1 needs to be added back in for the `top` prompt direction to make `-select=#` and `:UniteNext` work.