### PR TITLE
Strip more regexp ecapes in input completion

### DIFF
--- a/autoload/unite/helper.vim
+++ b/autoload/unite/helper.vim
@@ -581,7 +581,7 @@ endfunction"}}}
 function! unite#helper#complete_search_history(arglead, cmdline, cursorpos) "{{{
   return filter(map(unite#util#uniq(s:histget('search')
         \                           + s:histget('input')),
-        \           "substitute(v:val, '^\\\\<\\|\\\\>$', '', 'g')"),
+        \           "substitute(v:val, '\\c^\\(\\\\[cmv<]\\)*\\|\\\\>$', '', 'g')"),
         \ "stridx(tolower(v:val), tolower(a:arglead)) == 0")
 endfunction"}}}
 


### PR DESCRIPTION
Currently the completion function for grep patterns strips `\<` and `\>` from search history. This change makes it also strip any combination of `\c`/`\C`, `\m`/`\M`, `\v`/`\V` and `\<` from the front of the pattern.