### PR TITLE
Use more precise reltime for marked_time

### DIFF
--- a/autoload/unite/mappings.vim
+++ b/autoload/unite/mappings.vim
@@ -457,7 +457,8 @@ function! s:toggle_mark(map) "{{{
   let candidate = unite#helper#get_current_candidate()
   if !get(candidate, 'is_dummy', 0)
     let candidate.unite__is_marked = !candidate.unite__is_marked
-    let candidate.unite__marked_time = localtime()
+    let candidate.unite__marked_time = has('reltime') && has('float') ?
+          \ str2float(reltimestr(reltime())) : localtime()
 
     call unite#view#_redraw_line()
   endif


### PR DESCRIPTION
Using `localtime()` for candidates' `unite__marked_time` can sort incorrectly because its resolution is only one second, so two or more items selected in the same second can have the same value. Using `reltime()` when it's available fixes that.