### PR TITLE
Sort windows by recent access time

### DIFF
--- a/autoload/unite/sources/window.vim
+++ b/autoload/unite/sources/window.vim
@@ -30,12 +30,23 @@ function! unite#sources#window#define() "{{{
   return s:source
 endfunction"}}}
 
+function! unite#sources#window#sorter(candidates, context) abort "{{{
+  return unite#util#sort_by(a:candidates, '
+  \   -get(
+  \     gettabwinvar(
+  \       v:val.action__tab_nr, v:val.action__window_nr,
+  \       "unite_window", {}),
+  \     "time", 0)
+  \ ')
+endfunction"}}}
+
 let s:source = {
       \ 'name' : 'window',
       \ 'description' : 'candidates from window list',
       \ 'syntax' : 'uniteSource__Window',
       \ 'hooks' : {},
       \ 'default_kind' : 'window',
+      \ 'sorters': function('unite#sources#window#sorter'),
       \}
 
 function! s:source.hooks.on_init(args, context) "{{{


### PR DESCRIPTION
`window` source の候補をデフォルトでアクセス時間に並べるようにしました。


実装しましたが、個人的にやりたかったことは達成できていません。
私がやりたかったのは、`:Unite -force-immediately window:all:no-curret` で、直前のウィンドウと現在のウィンドウを行き来できるようにすることでした。
しかし実際には、`kind-window` の `jump` アクションおよび、`unite` ウィンドウを閉じる際に、関係ないウィンドウを経由してしまい、それらの最終アクセス時刻が更新されてしまうため、うまく行きません。
解決案として、最終アクセス時間の記録を一時的に無効化する機能を追加し、上記のタイミングで記録を止めるのがいいかと考えていますが、`jump` アクションはともかく、`unite` ウィンドウを閉じる方は本体に詳しくないと難しそうだったので、一旦諦めました。
この PR 自体はマージしてもらって大丈夫ですが、上記の問題について何か対応頂けるととても助かります。実装の方針や方法を示してもらえればこちらで対応することも可能です。