### PR TITLE
Safely handle unmodifiable buffers on insert

### DIFF
--- a/autoload/unite/handlers.vim
+++ b/autoload/unite/handlers.vim
@@ -40,8 +40,14 @@ function! unite#handlers#_on_insert_enter()  "{{{
 
   " Restore prompt
   let unite.prompt_linenr = unite.init_prompt_linenr
-  call append((unite.context.prompt_direction ==# 'below' ?
-        \ '$' : 0), '')
+  let modifiable_save = &l:modifiable
+  try
+    setlocal modifiable
+    call append((unite.context.prompt_direction ==# 'below' ?
+                \ '$' : 0), '')
+  finally
+    let &l:modifiable = modifiable_save
+  endtry
   call unite#view#_redraw_prompt()
 endfunction"}}}
 function! unite#handlers#_on_insert_leave()  "{{{


### PR DESCRIPTION
I was experiencing this error all the time.
Could be an issue with my configuration, but
this seems innocuous enough, and _redraw_prompt()
was doing it as well