### PR TITLE
Apply silent to opening preview window

### DIFF
--- a/autoload/unite/kinds/jump_list.vim
+++ b/autoload/unite/kinds/jump_list.vim
@@ -289,7 +289,7 @@ function! s:open(candidate) "{{{
     if has_key(a:candidate, 'action__buffer_nr')
       silent execute 'keepjumps buffer' bufnr
     else
-      call unite#util#smart_execute_command(
+      silent call unite#util#smart_execute_command(
             \ 'keepjumps edit!', unite#util#expand(
             \   fnamemodify(a:candidate.action__path, ':~:.')))
       let bufnr = bufnr('%')


### PR DESCRIPTION

auto-previewオプション使用時、プレビューウィンドウの表示切替時にsilentが適用されていないケースがあります。
出力が複数行になった場合に、下に示すような挙動になり、扱いづらいので修正していただきたいです。

![recorded](https://cloud.githubusercontent.com/assets/3838104/12694062/81bdc2f0-c763-11e5-87b3-bce821b48a60.gif)
