### PR TITLE
Set prev_pos in persist_open action

### DIFF
--- a/autoload/unite/kinds/openable.vim
+++ b/autoload/unite/kinds/openable.vim
@@ -160,6 +160,7 @@ function! s:kind.action_table.persist_open.func(candidate) abort "{{{
     execute winnr 'wincmd w'
   endif
   let unite.prev_winnr = winnr()
+  let unite.prev_pos = getpos('.')
 
   call unite#take_action('open', a:candidate)
   let unite.prev_bufnr = bufnr('%')


### PR DESCRIPTION
The cursor position after `persist_open` is lost when Unite is closed after https://github.com/Shougo/unite.vim/issues/1118. Saving `prev_pos` in `persist_open` fixes it.