### PR TITLE
Fix my typo in persist_open.func

### DIFF
--- a/autoload/unite/kinds/openable.vim
+++ b/autoload/unite/kinds/openable.vim
@@ -160,10 +160,10 @@ function! s:kind.action_table.persist_open.func(candidate) abort "{{{
     execute winnr 'wincmd w'
   endif
   let unite.prev_winnr = winnr()
-  let unite.prev_pos = getpos('.')
 
   call unite#take_action('open', a:candidate)
   let unite.prev_bufnr = bufnr('%')
+  let unite.prev_pos = getpos('.')
 
   if g:unite_kind_openable_persist_open_blink_time != ''
     let left = getpos("'<")


### PR DESCRIPTION
I accidentally put `getpos('.')` before the `open` action. This is the change I meant to make.