### PR TITLE
Don't set winfixheight/width without context.split

### DIFF
--- a/autoload/unite/init.vim
+++ b/autoload/unite/init.vim
@@ -190,10 +190,12 @@ function! unite#init#_unite_buffer() abort "{{{
       setlocal norelativenumber
     endif
 
-    if context.vertical
-      setlocal winfixwidth
-    else
-      setlocal winfixheight
+    if context.split
+      if context.vertical
+        setlocal winfixwidth
+      else
+        setlocal winfixheight
+      endif
     endif
 
     " Autocommands.


### PR DESCRIPTION
`winfixheight` and `winfixwidth` are window-local, not buffer-local, so they remain set after closing the Unite buffer if Unite wasn't opened in a split which can cause problems.