### PR TITLE
Implement UniteDo

### DIFF
--- a/autoload/unite/start.vim
+++ b/autoload/unite/start.vim
@@ -482,18 +482,18 @@ function! unite#start#_pos(buffer_name, direction, count) abort "{{{
   endtry
 endfunction"}}}
 
-function! unite#start#do_command(cmd)
-   " The step by step is done backwards because, if the command happens to
-   " include or exclude lines in the file, the remaining candidates don't have
-   " its position changed when the default action is applied.
+function! unite#start#_do_command(cmd)
+  " The step by step is done backwards because, if the command happens to
+  " include or exclude lines in the file, the remaining candidates don't have
+  " its position changed when the default action is applied.
 
-   silent! UniteLast
-   let current_pos = []
-   while current_pos != getpos('.')
-     silent! execute a:cmd
-     let current_pos = getpos('.')
-     silent! UnitePrevious
-   endwhile
+  silent! UniteLast
+  let current_pos = []
+  while current_pos != getpos('.')
+    silent! execute a:cmd
+    let current_pos = getpos('.')
+    silent! UnitePrevious
+  endwhile
 endfunction
 
 function! s:get_candidates(sources, context) abort "{{{

--- a/autoload/unite/start.vim
+++ b/autoload/unite/start.vim
@@ -482,7 +482,7 @@ function! unite#start#_pos(buffer_name, direction, count) abort "{{{
   endtry
 endfunction"}}}
 
-function! unite#do_command(cmd)
+function! unite#start#do_command(cmd)
    " The step by step is done backwards because, if the command happens to
    " include or exclude lines in the file, the remaining candidates don't have
    " its position changed when the default action is applied.

--- a/autoload/unite/start.vim
+++ b/autoload/unite/start.vim
@@ -482,6 +482,20 @@ function! unite#start#_pos(buffer_name, direction, count) abort "{{{
   endtry
 endfunction"}}}
 
+function! unite#do_command(cmd)
+   " The step by step is done backwards because, if the command happens to
+   " include or exclude lines in the file, the remaining candidates don't have
+   " its position changed when the default action is applied.
+
+   silent! UniteLast
+   let current_pos = []
+   while current_pos != getpos('.')
+     silent! execute a:cmd
+     let current_pos = getpos('.')
+     silent! UnitePrevious
+   endwhile
+endfunction
+
 function! s:get_candidates(sources, context) abort "{{{
   try
     let current_unite = unite#init#_current_unite(a:sources, a:context)

--- a/doc/unite.txt
+++ b/doc/unite.txt
@@ -383,6 +383,21 @@ COMMANDS 					*unite-commands*
 		buffer with {buffer-name}.
 		You can use it like |:clast|.
 
+:UniteDo {command}		         	*:UniteDo*
+		Executes a {command} for each candidate's default action.
+		You can use it like |:argdo|.
+
+		Example of use case:
+		https://github.com/Shougo/unite.vim/issues/1166
+
+		Limitations: If the candidates are lines in a file, UniteDo
+		assumes that either:
+		- {command} doesn't change the number of lines; or
+		- candidates are sorted in ascending order by line.
+
+		UniteDo might have unexpected behaviour if none of the
+		two conditions above are met.
+
 The commands of source				*:unite-sources-commands*
 
 :UniteBookmarkAdd [{file}]			*:UniteBookmarkAdd*

--- a/doc/unite.txt
+++ b/doc/unite.txt
@@ -389,7 +389,7 @@ COMMANDS 					*unite-commands*
 
 		Example:
 
-		Concider the JavaScript with the code below.
+		Concider a JavaScript file with the code below.
 >
 		/* jshint unused: true */
 		var variable = 1;

--- a/doc/unite.txt
+++ b/doc/unite.txt
@@ -387,9 +387,46 @@ COMMANDS 					*unite-commands*
 		Executes a {command} for each candidate's default action.
 		You can use it like |:argdo|.
 
-		Example of use case:
-		https://github.com/Shougo/unite.vim/issues/1166
+		Example:
 
+		Concider the JavaScript with the code below.
+>
+		/* jshint unused: true */
+		var variable = 1;
+		function foo () {
+		  console.log('Hello foo!')
+		}
+		function bar () {
+		  console.log('Good bye bar!')
+		}
+<
+		Apply JsHint (http://jshint.com/) linting tool to the
+		example.
+>
+		test.js: line 6, col 30, Missing semicolon.
+		test.js: line 10, col 33, Missing semicolon.
+		test.js: line 3, col 5, 'variable' is defined but never used.
+		test.js: line 5, col 10, 'foo' is defined but never used.
+		test.js: line 9, col 10, 'bar' is defined but never used.
+<
+		Syntastic (https://github.com/scrooloose/syntastic) can
+		use JsHint to populate the location list with those warnings.
+		So, use the quick fix external source to populate a Unite
+		buffer with those issues.
+>
+		:Unite localtion_list
+<
+		Use "semicolon" as narrowing text so there is only one type of
+		error.
+>
+		test.js: line 6, col 30, Missing semicolon.
+		test.js: line 10, col 33, Missing semicolon.
+<
+		Then, use UniteDo to apply a fix to these lines using a single
+		command.
+>
+		:UniteDo normal! A;
+<
 		Limitations: If the candidates are lines in a file, UniteDo
 		assumes that either:
 		- {command} doesn't change the number of lines; or

--- a/plugin/unite.vim
+++ b/plugin/unite.vim
@@ -78,7 +78,7 @@ command! -nargs=? -bar -complete=customlist,unite#complete#buffer_name
 command! -nargs=? -bar -complete=customlist,unite#complete#buffer_name
       \ UniteLast call unite#start#_pos(<q-args>, 'last', 1)
 command! -nargs=1 -complete=command
-      \ UniteDo call unite#start#do_command(<q-args>)
+      \ UniteDo call unite#start#_do_command(<q-args>)
 
 function! s:call_unite(command, args, line1, line2) abort "{{{
   let [args, context] = unite#helper#parse_options_user(a:args)

--- a/plugin/unite.vim
+++ b/plugin/unite.vim
@@ -78,7 +78,7 @@ command! -nargs=? -bar -complete=customlist,unite#complete#buffer_name
 command! -nargs=? -bar -complete=customlist,unite#complete#buffer_name
       \ UniteLast call unite#start#_pos(<q-args>, 'last', 1)
 command! -nargs=1 -complete=command
-      \ UniteDo call unite#do_command(<q-args>)
+      \ UniteDo call unite#start#do_command(<q-args>)
 
 function! s:call_unite(command, args, line1, line2) abort "{{{
   let [args, context] = unite#helper#parse_options_user(a:args)

--- a/plugin/unite.vim
+++ b/plugin/unite.vim
@@ -77,6 +77,8 @@ command! -nargs=? -bar -complete=customlist,unite#complete#buffer_name
       \ UniteFirst call unite#start#_pos(<q-args>, 'first', 1)
 command! -nargs=? -bar -complete=customlist,unite#complete#buffer_name
       \ UniteLast call unite#start#_pos(<q-args>, 'last', 1)
+command! -nargs=1 -complete=command
+      \ UniteDo call unite#do_command(<q-args>)
 
 function! s:call_unite(command, args, line1, line2) abort "{{{
   let [args, context] = unite#helper#parse_options_user(a:args)


### PR DESCRIPTION
As discussed in #1166, this pull request implements the UniteDo command.

Some relevant information:

Differently than the first proposed solution, this implementation navigates the candidates
in back order. This is so because, in case the command given as argument changes the
number of lines in the document, the UniteNext might end up navigating to the wrong point
in the file. This way, the output might be different than expected.