### PR TITLE
unite.txt: Fix doc referring to new variable.

### DIFF
--- a/doc/unite.txt
+++ b/doc/unite.txt
@@ -621,7 +621,7 @@ g:unite_source_grep_encoding			*g:unite_source_grep_encoding*
 
 		The default value is "char".
 
-g:unite_source_grep_encoding			*g:unite_source_grep_encoding*
+g:unite_source_grep_separator			*g:unite_source_grep_separator*
 		The grep argument separator.
 
 		The default value is "--" or ""(for jvgrep).


### PR DESCRIPTION
The commit adding unite_source_grep_separator used the wrong name, causing duplicate tag errors when running :helptags