### PR TITLE
Fix cursor up/down with count from prompt line

### DIFF
--- a/autoload/unite/mappings.vim
+++ b/autoload/unite/mappings.vim
@@ -738,7 +738,8 @@ function! unite#mappings#cursor_up(is_skip_not_matched) abort "{{{
     return repeat("\<Up>", cnt) .
         \ (unite#helper#is_prompt(line('.') - cnt) ? "\<End>" : "\<Home>")
   else
-    return cnt == 1 ? 'k' : cnt.'k'
+    let cnt += v:count == 0 ? 0 : (v:count - 1)
+    return "\<Esc>" . (cnt == 1 ? 'k' : cnt.'k')
   endif
 endfunction"}}}
 function! unite#mappings#cursor_down(is_skip_not_matched) abort "{{{
@@ -767,7 +768,8 @@ function! unite#mappings#cursor_down(is_skip_not_matched) abort "{{{
     return repeat("\<Down>", cnt) .
           \ (unite#helper#is_prompt(line('.') + cnt) ? "\<End>" : "\<Home>")
   else
-    return cnt == 1 ? 'j' : cnt.'j'
+    let cnt += v:count == 0 ? 0 : (v:count - 1)
+    return "\<Esc>" . (cnt == 1 ? 'j' : cnt.'j')
   endif
 endfunction"}}}
 function! s:smart_preview() abort "{{{


### PR DESCRIPTION
This fixes cursor motion when the cursor is on the prompt line and a count is given. To reproduce the problem:

 1. Make sure `g:unite_enable_auto_select` is enabled
 2. Open a Unite window and have the cursor on the prompt line
 3. Type "3j" is the prompt is at the top or "3k" if the prompt is below
 4. The cursor will move 31 lines down or up instead of 1 line because the cursor motion function returns "1j" resulting in "31j"

The fix is to add the count to the return value of the cursor motion function and cancel v:count using `<Esc>`.