### PR TITLE
Add terminal buftype for get_choose_windows ignore list.

### DIFF
--- a/autoload/unite/helper.vim
+++ b/autoload/unite/helper.vim
@@ -468,6 +468,7 @@ function! unite#helper#get_choose_windows() abort "{{{
         \ !getwinvar(v:val, '&previewwindow')
         \ && getwinvar(v:val, '&filetype') !=# 'vimfiler'
         \ && getwinvar(v:val, '&filetype') !=# 'unite'
+        \ && getwinvar(v:val, '&buftype') !~# 'terminal'
         \ && (getwinvar(v:val, '&buftype') !~# 'nofile'
         \   || getwinvar(v:val, '&buftype') =~# 'acwrite')
         \ && getwinvar(v:val, '&filetype') !=# 'qf'")


### PR DESCRIPTION
# 目的
vimfiler からファイルを開く際に、deol.nvim を表示している window を除外したい

# やったこと
unite#helper#get_choose_windows の中のフィルターに terminal を追加しました。

# 懸念
terminal buffer の window を指定してファイルを開きたい！という人がいないかどうか不明です。