### PR TITLE
grep/git: fix for pattern being interpreted as an option

### DIFF
--- a/autoload/unite/sources/grep_git.vim
+++ b/autoload/unite/sources/grep_git.vim
@@ -70,7 +70,7 @@ function! s:source.gather_candidates(args, context) abort "{{{
     let a:context.is_async = 1
   endif
 
-  let cmdline = printf('git grep -n --no-color %s %s -- %s',
+  let cmdline = printf('git grep -n --no-color %s -- %s %s',
     \   a:context.source__extra_opts,
     \   string(a:context.source__input),
     \   unite#helper#join_targets(a:context.source__targets),


### PR DESCRIPTION
@Shougo If your pattern for instance contains dash as first symbol (e.g. `-smth`) it fails with error about `-smth` isn't known option.