### PR TITLE
file_rec/git: don't share cache directory with file_rec/async

### DIFF
--- a/autoload/unite/sources/rec.vim
+++ b/autoload/unite/sources/rec.vim
@@ -609,6 +609,10 @@ endfunction"}}}
 function! s:source_file_git.complete(args, context, arglead, cmdline, cursorpos) abort "{{{
   return []
 endfunction"}}}
+function! s:source_file_git.hooks.on_init(args, context) abort "{{{
+  let a:context.source__is_directory = 0
+  call s:on_init(a:args, a:context, s:source_file_git.name)
+endfunction"}}}
 
 " Source directory.
 let s:source_directory_rec = deepcopy(s:source_file_rec)


### PR DESCRIPTION
`s:source_file_git` が `s:source_file_async` の `hooks.on_init` を再使用するため 
 `file_rec/git` を使用時 `a:context.source__name` が `s:source_file_async.name` にセットされてキャッシュが `file_rec/async` と共有されるので `file_rec/async` の結果とごちゃまぜになる時があるという問題を修正。よろしくお願いします m(_ _)m