### PR TITLE
fix rename: get the exact buffer number with the old filename

### DIFF
--- a/autoload/unite/kinds/file.vim
+++ b/autoload/unite/kinds/file.vim
@@ -181,7 +181,7 @@ function! unite#kinds#file#do_rename(old_filename, new_filename) abort "{{{
       call mkdir(fnamemodify(new_filename, ':h'), 'p')
     endif
 
-    let bufnr = bufnr(old_filename)
+    let bufnr = get(filter(range(bufnr('$')), 'bufname(v:val) ==# old_filename'), 0, -1)
     if bufnr > 0
       " Buffer rename.
       setlocal hidden


### PR DESCRIPTION
This pull request fixes rename action. With current implementation the action fails to rename directory where some file in the directory is loaded.

### Steps to reproduce
```
 $ mkdir foo
 $ touch foo/bar
 $ vim foo/bar
:VimFiler
:echo bufnr('foo') // prints 1 because bufname(1) ==# 'foo/bar'
rqux<CR> // rename foo directory, not foo/bar file
```

### Expected behavior
The foo directory is renamed to qux.
 
### Actual behavior
New qux file (not directory) is created and foo directory is not renamed.